### PR TITLE
Fix some issues discovered by compiler warnings

### DIFF
--- a/src/efi-application.c
+++ b/src/efi-application.c
@@ -154,6 +154,7 @@ __pecoff_rehash_old(tpm_event_log_rehash_ctx_t *ctx, const char *filename)
 	char cmdbuf[8192], linebuf[1024];
 	const tpm_evdigest_t *md = NULL;
 	FILE *fp;
+	int exitcode;
 
 	snprintf(cmdbuf, sizeof(cmdbuf),
 			"pesign --hash --in %s --digest_type %s",
@@ -180,8 +181,13 @@ __pecoff_rehash_old(tpm_event_log_rehash_ctx_t *ctx, const char *filename)
 		break;
 	}
 
-	if (fclose(fp) != 0)
-		fatal("pesign command failed: %m\n");
+	exitcode = pclose(fp);
+	if (exitcode == -1)
+		fatal("pclose failed: %m\n");
+	else if (!WIFEXITED(exitcode))
+		fatal("pesign command failed\n");
+	else if (WEXITSTATUS(exitcode) != 0)
+		fatal("pesign command failed with %d\n", WEXITSTATUS(exitcode));
 
 	return md;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -267,7 +267,7 @@ __convert_from_utf16le(char *in_string, size_t in_bytes, char *out_string, size_
 		converted = iconv(ctx,
 				&in_string, &in_bytes,
 				&out_string, &out_bytes);
-		if (converted < 0) {
+		if (converted == (size_t) -1) {
 			perror("iconv");
 			return false;
 		}
@@ -290,7 +290,7 @@ __convert_to_utf16le(char *in_string, size_t in_bytes, char *out_string, size_t 
 		converted = iconv(ctx,
 				&in_string, &in_bytes,
 				&out_string, &out_bytes);
-		if (converted < 0) {
+		if (converted == (size_t) -1) {
 			perror("iconv");
 			return false;
 		}


### PR DESCRIPTION
- Use pclose instead of fclose and handle the various return values
- Actually catch iconv errors by using (size_t) -1 (the man page specifies it exactly like that)