### PR TITLE
oracle: fix crash when testcase recording is disabled

### DIFF
--- a/src/oracle.c
+++ b/src/oracle.c
@@ -347,7 +347,8 @@ pcr_bank_init_from_current(tpm_pcr_bank_t *bank)
 			fprintf(recording, "%02u sha256 %s\n", i, digest_print_value(pcr));
 	}
 
-	fclose(recording);
+	if (recording)
+		fclose(recording);
 }
 
 static void


### PR DESCRIPTION
pcr_bank_init_from_current() tried to close the recording file even though testcase recording was disabled and this led to a crash.

Signed-off-by: Gary Lin <glin@suse.com>