### PR TITLE
Handle NO_ACTION events when predicting PCR values

### DIFF
--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -257,6 +257,11 @@ typedef struct tpm_parsed_event {
 
 typedef struct tpm_event_log_reader tpm_event_log_reader_t;
 
+typedef struct tpm_startup_event {
+	char signature[16];
+	uint8_t locality;
+} tpm_startup_event_t;
+
 extern tpm_event_log_reader_t *	event_log_open(void);
 extern void			event_log_close(tpm_event_log_reader_t *log);
 extern tpm_event_t *		event_log_read_next(tpm_event_log_reader_t *log);


### PR DESCRIPTION
Per "TCG PC Client Platform Firmware Profile Specification", there are 3 types of NO_ACTION events:

1. Specification ID event
2. Reference Manifest event
3. Startup Locality event

The first two types are not measured so those events must be skipped when predicting PCR values. On the other hand, the Startup Locality event may change the initial PCR0 value. A Startup Locality event is always the first event and for PCR0, and the last byte of PCR0 has to be set to the locality value.

Fixes: https://github.com/okirch/pcr-oracle/issues/13

Signed-off-by: Gary Lin <glin@suse.com>