### PR TITLE
Remove authorized policy file from the unseal action

### DIFF
--- a/src/oracle.c
+++ b/src/oracle.c
@@ -1119,12 +1119,10 @@ main(int argc, char **argv)
 		break;
 
 	case ACTION_UNSEAL:
-		if (opt_authorized_policy) {
-			if (opt_rsa_public_key == NULL)
-				usage(1, "You need to specify the --public-key option when unsealing using an authorized policy\n");
-			if (opt_pcr_policy == NULL)
-				usage(1, "You need to specify the --pcr-policy option when unsealing using an authorized policy\n");
-		}
+		if (opt_rsa_public_key == NULL && opt_pcr_policy)
+			usage(1, "You need to specify the --public-key option when unsealing using an authorized policy\n");
+		if (opt_pcr_policy == NULL && opt_rsa_public_key)
+			usage(1, "You need to specify the --pcr-policy option when unsealing using an authorized policy\n");
 		pcr_selection = get_pcr_selection_argument(argc, argv, opt_algo);
 		end_arguments(argc, argv);
 		break;
@@ -1175,9 +1173,9 @@ main(int argc, char **argv)
 	}
 
 	if (action == ACTION_UNSEAL) {
-		if (opt_authorized_policy) {
+		if (opt_rsa_public_key) {
 			/* input is the sealed secret, output is the cleartext */
-			if (!pcr_authorized_policy_unseal_secret(pcr_selection, opt_authorized_policy, opt_pcr_policy, opt_rsa_public_key, opt_input, opt_output))
+			if (!pcr_authorized_policy_unseal_secret(pcr_selection, opt_pcr_policy, opt_rsa_public_key, opt_input, opt_output))
 				return 1;
 		} else {
 			if (!pcr_unseal_secret(pcr_selection, opt_input, opt_output))

--- a/src/pcr-policy.c
+++ b/src/pcr-policy.c
@@ -1213,7 +1213,6 @@ out:
  */
 bool
 pcr_authorized_policy_unseal_secret(const tpm_pcr_selection_t *pcr_selection,
-				const char *authpolicy_path,
 				const char *signed_policy_path,
 				const char *rsakey_path,
                                 const char *input_path, const char *output_path)

--- a/src/pcr.h
+++ b/src/pcr.h
@@ -63,7 +63,6 @@ extern bool		pcr_policy_sign(const tpm_pcr_bank_t *bank,
 extern bool		pcr_authorized_policy_seal_secret(const char *authorized_policy,
 				const char *input_path, const char *output_path);
 extern bool		pcr_authorized_policy_unseal_secret(const tpm_pcr_selection_t *pcr_selection,
-				const char *authorized_policy,
 				const char *signed_policy_path,
 				const char *rsakey_path,
 				const char *input_path, const char *output_path);

--- a/test-authorized.sh
+++ b/test-authorized.sh
@@ -59,7 +59,6 @@ for attempt in first second; do
 
 	echo "$attempt attempt to unseal the secret"
 	call_oracle \
-		--auth authorized.policy \
 		--input sealed \
 		--output recovered \
 		--public-key policy-pubkey \
@@ -85,7 +84,6 @@ for attempt in first second; do
 	tpm2_pcrextend 12:sha256=21d2013e3081f1e455fdd5ba6230a8620c3cfc9a9c31981d857fe3891f79449e
 	rm -f recovered
 	call_oracle \
-		--auth authorized.policy \
 		--input sealed \
 		--output recovered \
 		--public-key policy-pubkey \


### PR DESCRIPTION
When unsealing the key sealed by an authorized policy, it only needs the public key, signed PCR policy, and the sealed key. Get rid of the option for authorized policy file from the unseal action to avoid the confusion.