### PR TITLE
Unseal the data without calling __pcr_policy_make()

### DIFF
--- a/src/pcr-policy.c
+++ b/src/pcr-policy.c
@@ -782,8 +782,6 @@ esys_unseal_authorized(ESYS_CONTEXT *esys_context,
 		warning("%s: bad hash %x\n", __func__, policy_signature->signature.rsassa.hash);
 
 	pcr_bank_to_selection(&pcrs, bank);
-	if (!(pcr_policy = __pcr_policy_make(esys_context, bank)))
-		goto cleanup;
 
 	rc = Esys_LoadExternal(esys_context,
 			ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, NULL,
@@ -794,22 +792,6 @@ esys_unseal_authorized(ESYS_CONTEXT *esys_context,
 
 	rc = Esys_TR_GetName(esys_context, pub_key_handle, &public_key_name);
 	if (!__tss_check_error(rc, "Esys_TR_GetName failed"))
-		goto cleanup;
-
-	rc = Esys_Hash(esys_context,
-			ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
-			(const TPM2B_MAX_BUFFER *) pcr_policy,
-			TPM2_ALG_SHA256, esys_tr_rh_null,
-			&pcr_policy_hash, NULL);
-	if (!__tss_check_error(rc, "Esys_Hash failed"))
-		goto cleanup;
-
-	rc = Esys_VerifySignature(esys_context,
-			pub_key_handle,
-			ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
-			pcr_policy_hash, policy_signature,
-			&verification_ticket);
-	if (!__tss_check_error(rc, "Esys_VerifySignature failed"))
 		goto cleanup;
 
 	if (!esys_create_primary(esys_context, &primary_handle))
@@ -832,6 +814,27 @@ esys_unseal_authorized(ESYS_CONTEXT *esys_context,
 			ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
 			&empty_digest, &pcrs);
 	if (!__tss_check_error(rc, "Esys_PolicyPCR failed"))
+		goto cleanup;
+
+	rc = Esys_PolicyGetDigest(esys_context, session_handle, ESYS_TR_NONE,
+			ESYS_TR_NONE, ESYS_TR_NONE, &pcr_policy);
+	if (!__tss_check_error(rc, "Esys_PolicyGetDigest failed"))
+		goto cleanup;
+
+	rc = Esys_Hash(esys_context,
+			ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+			(const TPM2B_MAX_BUFFER *) pcr_policy,
+			TPM2_ALG_SHA256, esys_tr_rh_null,
+			&pcr_policy_hash, NULL);
+	if (!__tss_check_error(rc, "Esys_Hash failed"))
+		goto cleanup;
+
+	rc = Esys_VerifySignature(esys_context,
+			pub_key_handle,
+			ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+			pcr_policy_hash, policy_signature,
+			&verification_ticket);
+	if (!__tss_check_error(rc, "Esys_VerifySignature failed"))
 		goto cleanup;
 
 	TPM2B_NONCE policyRef = { .size = 0 };


### PR DESCRIPTION
To get the policy digest for Esys_VerifySignature(), it's not necessary to recalculate the digest with __pcr_policy_make(). This commit reorganizes the TPM command sequence to fetch the policy digest right after PolicyPCR, so that we can remove __pcr_policy_make() to simplify the whole unsealing process.