### PR TITLE
Add TPM 2.0 Key File support to 'seal-secret' and 'sign'

### DIFF
--- a/src/oracle.c
+++ b/src/oracle.c
@@ -90,6 +90,7 @@ enum {
 	OPT_OUTPUT,
 	OPT_AUTHORIZED_POLICY,
 	OPT_PCR_POLICY,
+	OPT_KEY_FORMAT,
 };
 
 static struct option options[] = {
@@ -116,6 +117,7 @@ static struct option options[] = {
 	{ "output",		required_argument,	0,	OPT_OUTPUT },
 	{ "authorized-policy",	required_argument,	0,	OPT_AUTHORIZED_POLICY },
 	{ "pcr-policy",		required_argument,	0,	OPT_PCR_POLICY },
+	{ "key-format",		required_argument,	0,	OPT_KEY_FORMAT },
 
 	{ NULL }
 };
@@ -995,6 +997,8 @@ main(int argc, char **argv)
 	char *opt_rsa_private_key = NULL;
 	char *opt_rsa_public_key = NULL;
 	bool opt_rsa_generate = false;
+	char *opt_key_format = NULL;
+	bool tpm2key_fmt = false;
 	int c, exit_code = 0;
 
 	while ((c = getopt_long(argc, argv, "dhA:CF:LSZ", options, NULL)) != EOF) {
@@ -1068,6 +1072,9 @@ main(int argc, char **argv)
 		case OPT_PCR_POLICY:
 			opt_pcr_policy = optarg;
 			break;
+		case OPT_KEY_FORMAT:
+			opt_key_format = optarg;
+			break;
 		case 'h':
 			usage(0, NULL);
 		default:
@@ -1085,6 +1092,14 @@ main(int argc, char **argv)
 
 	if (opt_create_testcase)
 		runtime_record_testcase(testcase_alloc(opt_create_testcase));
+
+	if (!opt_key_format || !strcasecmp(opt_key_format, "raw"))
+		tpm2key_fmt = false;
+	else
+	if (!strcasecmp(opt_key_format, "tpm2.0"))
+		tpm2key_fmt = true;
+	else
+		fatal("Unsupported key format \"%s\"\n", opt_key_format);
 
 	/* Validate options */
 	switch (action) {
@@ -1132,6 +1147,10 @@ main(int argc, char **argv)
 	case ACTION_SIGN:
 		if (opt_rsa_private_key == NULL)
 			usage(1, "You need to specify the --private-key option when signing a policy\n");
+		if (tpm2key_fmt) {
+			if (opt_input == NULL)
+				usage(1, "You need to specify the --input option when signing a policy into a TPM 2.0 Key file\n");
+		}
 		pcr_selection = get_pcr_selection_argument(argc, argv, opt_algo);
 		end_arguments(argc, argv);
 		break;
@@ -1168,7 +1187,7 @@ main(int argc, char **argv)
 	/* When sealing a secret against an authorized policy, there's no need to
 	 * mess around with PCR values. That's the beauty of it... */
 	if (action == ACTION_SEAL && opt_authorized_policy) {
-		if (!pcr_authorized_policy_seal_secret(opt_authorized_policy, opt_input, opt_output))
+		if (!pcr_authorized_policy_seal_secret(tpm2key_fmt, opt_authorized_policy, opt_input, opt_output))
 			return 1;
 
 		return 0;
@@ -1207,11 +1226,11 @@ main(int argc, char **argv)
 	} else
 	if (action == ACTION_SEAL) {
 		/* TBD - seal secret against a set of PCR values */
-		if (!pcr_seal_secret(&pred->prediction, opt_input, opt_output))
+		if (!pcr_seal_secret(tpm2key_fmt, &pred->prediction, opt_input, opt_output))
 			return 1;
 	} else
 	if (action == ACTION_SIGN) {
-		if (!pcr_policy_sign(&pred->prediction, opt_rsa_private_key, opt_output))
+		if (!pcr_policy_sign(tpm2key_fmt, &pred->prediction, opt_rsa_private_key, opt_input, opt_output))
 			return 1;
 	}
 

--- a/src/pcr-policy.c
+++ b/src/pcr-policy.c
@@ -37,6 +37,7 @@
 #include "rsa.h"
 #include "bufparser.h"
 #include "config.h"
+#include "tpm2key.h"
 
 static const TPM2B_PUBLIC SRK_template = {
 	.size = sizeof(TPMT_PUBLIC),
@@ -670,12 +671,15 @@ esys_create(ESYS_CONTEXT *esys_context,
 }
 
 static bool
-esys_seal_secret(ESYS_CONTEXT *esys_context, TPM2B_DIGEST *policy, const char *input_path, const char *output_path)
+esys_seal_secret(const bool tpm2key_fmt, ESYS_CONTEXT *esys_context,
+		 TPM2B_DIGEST *policy, const TPML_PCR_SELECTION *pcr_sel,
+		 const char *input_path, const char *output_path)
 {
 	TPM2B_SENSITIVE_DATA *secret = NULL;
 	TPM2B_PRIVATE *sealed_private = NULL;
 	TPM2B_PUBLIC *sealed_public = NULL;
 	ESYS_TR srk_handle = ESYS_TR_NONE;
+	TSSPRIVKEY *tpm2key = NULL;
 	bool ok = false;
 
 	if (!(secret = read_secret(input_path)))
@@ -689,7 +693,17 @@ esys_seal_secret(ESYS_CONTEXT *esys_context, TPM2B_DIGEST *policy, const char *i
 	if (!esys_create(esys_context, srk_handle, policy, secret, &sealed_private, &sealed_public))
 		goto cleanup;
 
-	ok = write_sealed_secret(output_path, sealed_public, sealed_private);
+	if (tpm2key_fmt) {
+		if (!tpm2key_basekey(&tpm2key, TPM2_RH_OWNER, sealed_public, sealed_private))
+			goto cleanup;
+
+		if (pcr_sel && !tpm2key_add_policy_policypcr(tpm2key, pcr_sel))
+			goto cleanup;
+
+		ok = tpm2key_write_file(output_path, tpm2key);
+	} else
+		ok = write_sealed_secret(output_path, sealed_public, sealed_private);
+
 	if (ok)
 		infomsg("Sealed secret written to %s\n", output_path?: "(standard output)");
 
@@ -700,6 +714,8 @@ cleanup:
 		free(sealed_public);
 	if (secret)
 		free_secret(secret);
+	if (tpm2key)
+		TSSPRIVKEY_free(tpm2key);
 
 	esys_flush_context(esys_context, &srk_handle);
 	return ok;
@@ -1036,16 +1052,22 @@ cleanup:
 }
 
 bool
-pcr_seal_secret(const tpm_pcr_bank_t *bank, const char *input_path, const char *output_path)
+pcr_seal_secret(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
+		const char *input_path, const char *output_path)
 {
 	ESYS_CONTEXT *esys_context = tss_esys_context();
 	TPM2B_DIGEST *pcr_policy = NULL;
+	TPML_PCR_SELECTION pcr_sel;
 	bool ok = false;
 
 	if (!(pcr_policy = __pcr_policy_make(esys_context, bank)))
 		return false;
 
-	ok = esys_seal_secret(esys_context, pcr_policy, input_path, output_path);
+	if (!pcr_bank_to_selection(&pcr_sel, bank))
+		return false;
+
+	ok = esys_seal_secret(tpm2key_fmt, esys_context, pcr_policy, &pcr_sel,
+			      input_path, output_path);
 
 	free(pcr_policy);
 	return ok;
@@ -1105,7 +1127,8 @@ pcr_authorized_policy_create(const tpm_pcr_selection_t *pcr_selection, const cha
 }
 
 bool
-pcr_authorized_policy_seal_secret(const char *authpolicy_path, const char *input_path, const char *output_path)
+pcr_authorized_policy_seal_secret(const bool tpm2key_fmt, const char *authpolicy_path,
+				  const char *input_path, const char *output_path)
 {
 	ESYS_CONTEXT *esys_context = tss_esys_context();
 	TPM2B_DIGEST *authorized_policy = NULL;
@@ -1114,7 +1137,8 @@ pcr_authorized_policy_seal_secret(const char *authpolicy_path, const char *input
 	if (!(authorized_policy = read_digest(authpolicy_path)))
 		return false;
 
-	ok = esys_seal_secret(esys_context, authorized_policy, input_path, output_path);
+	ok = esys_seal_secret(tpm2key_fmt, esys_context, authorized_policy, NULL,
+			      input_path, output_path);
 	free(authorized_policy);
 	return ok;
 }
@@ -1170,17 +1194,31 @@ cleanup:
  * expected PCR values, and signing the resulting digest.
  */
 bool
-pcr_policy_sign(const tpm_pcr_bank_t *bank, const char *rsakey_path, const char *output_path)
+pcr_policy_sign(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank, const char *rsakey_path,
+		const char *input_path, const char *output_path)
 {
 	ESYS_CONTEXT *esys_context = tss_esys_context();
 	TPM2B_DIGEST *pcr_policy = NULL;
 	tpm_rsa_key_t *rsa_key = NULL;
 	TPM2B_PUBLIC *pub_key = NULL;
 	TPMT_SIGNATURE *signed_policy = NULL;
+	TSSPRIVKEY *tpm2key = NULL;
+	TPML_PCR_SELECTION pcr_sel;
 	bool okay = false;
 
 	if (!(rsa_key = tpm_rsa_key_read_private(rsakey_path)))
 		goto out;
+
+	if (tpm2key_fmt) {
+		if (!(pub_key = tpm_rsa_key_to_tss2(rsa_key)))
+			goto out;
+
+		if (!tpm2key_read_file(input_path, &tpm2key))
+			goto out;
+
+		if (!pcr_bank_to_selection(&pcr_sel, bank))
+			goto out;
+	}
 
 	if (!(pcr_policy = __pcr_policy_make(esys_context, bank)))
 		goto out;
@@ -1188,8 +1226,19 @@ pcr_policy_sign(const tpm_pcr_bank_t *bank, const char *rsakey_path, const char 
 	if (!__pcr_policy_sign(rsa_key, pcr_policy, &signed_policy))
 		goto out;
 
-	if (!write_signature(output_path, signed_policy))
-		goto out;
+	if (tpm2key) {
+		/* Prepend the signed policy */
+		if (!tpm2key_add_authpolicy_policyauthorize(tpm2key, "default",
+							    &pcr_sel, pub_key,
+							    signed_policy, false))
+			goto out;
+
+		if (!tpm2key_write_file(output_path, tpm2key))
+			goto out;
+	} else {
+		if (!write_signature(output_path, signed_policy))
+			goto out;
+	}
 	infomsg("Signed PCR policy written to %s\n", output_path?: "(standard output)");
 	okay = true;
 
@@ -1202,6 +1251,8 @@ out:
 		free(pub_key);
 	if (rsa_key)
 		tpm_rsa_key_free(rsa_key);
+	if (tpm2key)
+		TSSPRIVKEY_free(tpm2key);
 
 	return okay;
 }
@@ -1268,4 +1319,3 @@ cleanup:
 
 	return okay;
 }
-

--- a/src/pcr.h
+++ b/src/pcr.h
@@ -58,16 +58,18 @@ extern bool		pcr_read_into_bank(tpm_pcr_bank_t *bank);
 extern bool		pcr_authorized_policy_create(const tpm_pcr_selection_t *pcr_selection,
 				const char *rsakey_path, const char *output_path);
 extern bool		pcr_store_public_key(const char *rsakey_path, const char *output_path);
-extern bool		pcr_policy_sign(const tpm_pcr_bank_t *bank,
-				const char *rsakey_path, const char *output_path);
-extern bool		pcr_authorized_policy_seal_secret(const char *authorized_policy,
-				const char *input_path, const char *output_path);
+extern bool		pcr_policy_sign(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
+				const char *rsakey_path, const char *input_path,
+				const char *output_path);
+extern bool		pcr_authorized_policy_seal_secret(const bool tpm2key_fmt,
+				const char *authorized_policy, const char *input_path,
+				const char *output_path);
 extern bool		pcr_authorized_policy_unseal_secret(const tpm_pcr_selection_t *pcr_selection,
 				const char *authorized_policy,
 				const char *signed_policy_path,
 				const char *rsakey_path,
 				const char *input_path, const char *output_path);
-extern bool		pcr_seal_secret(const tpm_pcr_bank_t *bank,
+extern bool		pcr_seal_secret(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
 				const char *input_path, const char *output_path);
 extern bool		pcr_unseal_secret(const tpm_pcr_selection_t *pcr_selection,
 				const char *input_path, const char *output_path);

--- a/src/tpm2key-asn.h
+++ b/src/tpm2key-asn.h
@@ -1,0 +1,108 @@
+/*
+ *Copyright (C) 2016 James Bottomley <James.Bottomley@HansenPartnership.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Note: The ASN.1 defines constitute an interface specification for
+ * the openssl key format which may be copied by other implementations
+ * as fair use regardless of licence
+ */
+#ifndef _TPM2KEY_ASN_H
+#define _TPM2KEY_ASN_H
+
+#include <openssl/asn1t.h>
+#include <openssl/pem.h>
+
+/*
+ * Define the format of policy commands required for TPM enhanced authorization.
+ *
+ * TPMPolicy ::= SEQUENCE {
+ *	CommandCode		[0] EXPLICIT INTEGER
+ *	CommandPolicy		[1] EXPLICIT OCTET STRING
+ * }
+ */
+typedef struct {
+	ASN1_INTEGER *CommandCode;
+	ASN1_OCTET_STRING *CommandPolicy;
+} TSSOPTPOLICY;
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000
+DECLARE_STACK_OF(TSSOPTPOLICY);
+#define sk_TSSOPTPOLICY_new_null() SKM_sk_new_null(TSSOPTPOLICY)
+#define sk_TSSOPTPOLICY_push(sk, policy) SKM_sk_push(TSSOPTPOLICY, sk, policy)
+#define sk_TSSOPTPOLICY_pop(sk) SKM_sk_pop(TSSOPTPOLICY, sk)
+#define sk_TSSOPTPOLICY_free(sk) SKM_sk_free(TSSOPTPOLICY, sk)
+#define sk_TSSOPTPOLICY_num(policy) SKM_sk_num(TSSOPTPOLICY, policy)
+#define sk_TSSOPTPOLICY_value(policy, i) SKM_sk_value(TSSOPTPOLICY, policy, i)
+#else
+DEFINE_STACK_OF(TSSOPTPOLICY);
+#endif
+
+/*
+ * Define the format of optional authorization policy.  The policy for
+ * the key must begin with a TPM2_PolicyAuthorize statement with a
+ * nonce and pub key but empty signature.  Each element of the
+ * AuthPolicy->Policy array must end with TPM2_PolicyAuthorize with
+ * empty nonce and pubkey but polulated signature which is a hash of
+ * nonce || this policy
+ *
+ * TPMAuthPolicy ::= {
+ *      Name                  [0] EXPLICIT UTF8STRING OPTIONAL
+ *      Policy                [1] EXPLICIT SEQUENCE OF TPMPolicy
+ * }
+ */
+typedef struct {
+	ASN1_STRING *name;
+	STACK_OF(TSSOPTPOLICY) *policy;
+} TSSAUTHPOLICY;
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000
+DECLARE_STACK_OF(TSSAUTHPOLICY);
+#define sk_TSSAUTHPOLICY_new_null() SKM_sk_new_null(TSSAUTHPOLICY)
+#define sk_TSSAUTHPOLICY_push(sk, policy) SKM_sk_push(TSSAUTHPOLICY, sk, policy)
+#define sk_TSSAUTHPOLICY_pop(sk) SKM_sk_pop(TSSAUTHPOLICY, sk)
+#define sk_TSSAUTHPOLICY_free(sk) SKM_sk_free(TSSAUTHPOLICY, sk)
+#define sk_TSSAUTHPOLICY_num(policy) SKM_sk_num(TSSAUTHPOLICY, policy)
+#define sk_TSSAUTHPOLICY_value(policy, i) SKM_sk_value(TSSAUTHPOLICY, policy, i)
+#else
+DEFINE_STACK_OF(TSSAUTHPOLICY);
+#endif
+
+/*
+ * Define the format of a TPM key file.
+ *
+ * TPMKey ::= SEQUENCE {
+ *	type		OBJECT IDENTIFIER
+ *	emptyAuth	[0] EXPLICIT BOOLEAN OPTIONAL
+ *	policy		[1] EXPLICIT SEQUENCE OF TPMPolicy OPTIONAL
+ *	secret		[2] EXPLICIT OCTET STRING OPTIONAL
+ *	authPolicy	[3] EXPLICIT SEQUENCE OF TPMAuthPolicy OPTIONAL
+ *	parent		INTEGER
+ *	pubkey		OCTET STRING
+ *	privkey		OCTET STRING
+ * }
+ */
+
+typedef struct {
+	ASN1_OBJECT *type;
+	ASN1_BOOLEAN emptyAuth;
+	STACK_OF(TSSOPTPOLICY) *policy;
+	ASN1_OCTET_STRING *secret;
+	STACK_OF(TSSAUTHPOLICY) *authPolicy;
+	ASN1_INTEGER *parent;
+	ASN1_OCTET_STRING *pubkey;
+	ASN1_OCTET_STRING *privkey;
+} TSSPRIVKEY;
+
+#define OID_sealedData			"2.23.133.10.1.5"
+
+/* This is the PEM guard tag */
+#define TSSPRIVKEY_PEM_STRING "TSS2 PRIVATE KEY"
+
+DECLARE_ASN1_FUNCTIONS(TSSOPTPOLICY);
+DECLARE_ASN1_FUNCTIONS(TSSAUTHPOLICY);
+DECLARE_ASN1_FUNCTIONS(TSSPRIVKEY);
+DECLARE_PEM_write_bio(TSSPRIVKEY, TSSPRIVKEY);
+DECLARE_PEM_read_bio(TSSPRIVKEY, TSSPRIVKEY);
+
+#endif

--- a/src/tpm2key.c
+++ b/src/tpm2key.c
@@ -1,0 +1,284 @@
+/*
+ *   Copyright (C) 2023 SUSE LLC
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#include <openssl/asn1.h>
+#include <openssl/bio.h>
+#include <tss2_mu.h>
+
+#include "bufparser.h"
+#include "tpm2key-asn.h"
+#include "util.h"
+
+bool
+tpm2key_basekey(TSSPRIVKEY **tpm2key, const TPM2_HANDLE parent,
+		const TPM2B_PUBLIC *sealed_pub,
+		const TPM2B_PRIVATE *sealed_priv)
+{
+	TSSPRIVKEY *key;
+	buffer_t *bp_pub;
+	buffer_t *bp_priv;
+	TPM2_RC rc;
+
+	bp_pub = buffer_alloc_write(sizeof(*sealed_pub));
+	bp_priv = buffer_alloc_write(sizeof(*sealed_priv));
+
+	rc = Tss2_MU_TPM2B_PUBLIC_Marshal(sealed_pub, bp_pub->data, bp_pub->size,
+					  &bp_pub->wpos);
+	if (rc != TSS2_RC_SUCCESS)
+		return false;
+
+	rc = Tss2_MU_TPM2B_PRIVATE_Marshal(sealed_priv, bp_priv->data, bp_priv->size,
+					   &bp_priv->wpos);
+	if (rc != TSS2_RC_SUCCESS)
+		return false;
+
+	key = TSSPRIVKEY_new();
+	if (key == NULL)
+		return false;
+
+	key->type = OBJ_txt2obj(OID_sealedData, 1);
+	key->emptyAuth = 1;
+	key->parent = ASN1_INTEGER_new();
+	ASN1_INTEGER_set(key->parent, parent);
+
+	key->pubkey = ASN1_OCTET_STRING_new();
+	ASN1_STRING_set(key->pubkey, bp_pub->data, buffer_available(bp_pub));
+	key->privkey = ASN1_OCTET_STRING_new();
+	ASN1_STRING_set(key->privkey, bp_priv->data, buffer_available(bp_priv));
+
+	*tpm2key = key;
+
+	return true;
+}
+
+static bool
+__policy_add_policypcr(STACK_OF(TSSOPTPOLICY) *policy_seq, const TPML_PCR_SELECTION *pcr_sel)
+{
+	TSSOPTPOLICY *policy;
+	TPM2B_DIGEST pcr_digest = {.size = 0};
+	buffer_t *bp;
+	TPM2_RC rc;
+
+	policy = TSSOPTPOLICY_new();
+	if (policy == NULL)
+		return false;
+
+	bp = buffer_alloc_write(sizeof(pcr_digest) + sizeof(*pcr_sel));
+	if (bp == NULL)
+		return false;
+
+	rc = Tss2_MU_TPM2B_DIGEST_Marshal(&pcr_digest, bp->data, sizeof(pcr_digest), &bp->wpos);
+	if (rc != TSS2_RC_SUCCESS)
+		return false;
+
+	rc = Tss2_MU_TPML_PCR_SELECTION_Marshal(pcr_sel, bp->data, sizeof(*pcr_sel), &bp->wpos);
+	if (rc != TSS2_RC_SUCCESS)
+		return false;
+
+	ASN1_INTEGER_set(policy->CommandCode, TPM2_CC_PolicyPCR);
+	ASN1_STRING_set(policy->CommandPolicy, bp->data, buffer_available(bp));
+
+	sk_TSSOPTPOLICY_push(policy_seq, policy);
+
+	return true;
+}
+
+static bool
+__policy_add_policyauthorize(STACK_OF(TSSOPTPOLICY) *policy_seq,
+			     const TPM2B_PUBLIC *pub_key,
+			     const TPMT_SIGNATURE *signature)
+{
+	TSSOPTPOLICY *policy;
+	TPM2B_DIGEST policy_ref = {.size = 0};
+	buffer_t *bp;
+	TPM2_RC rc;
+
+	policy = TSSOPTPOLICY_new();
+	if (policy == NULL)
+		return false;
+
+	bp = buffer_alloc_write(sizeof(*pub_key) + sizeof(policy_ref) +
+				sizeof(*signature));
+	if (bp == NULL)
+		return false;
+
+	rc = Tss2_MU_TPM2B_PUBLIC_Marshal(pub_key, bp->data, bp->size, &bp->wpos);
+	if (rc != TSS2_RC_SUCCESS)
+		return false;
+
+	rc = Tss2_MU_TPM2B_DIGEST_Marshal(&policy_ref, bp->data, bp->size, &bp->wpos);
+	if (rc != TSS2_RC_SUCCESS)
+		return false;
+
+	rc = Tss2_MU_TPMT_SIGNATURE_Marshal(signature, bp->data, bp->size, &bp->wpos);
+	if (rc != TSS2_RC_SUCCESS)
+		return false;
+
+	ASN1_INTEGER_set(policy->CommandCode, TPM2_CC_PolicyAuthorize);
+	ASN1_STRING_set(policy->CommandPolicy, bp->data, buffer_available(bp));
+
+	sk_TSSOPTPOLICY_push(policy_seq, policy);
+
+	return true;
+}
+
+bool
+tpm2key_add_policy_policypcr(TSSPRIVKEY *tpm2key, const TPML_PCR_SELECTION *pcr_sel)
+{
+	if (tpm2key->policy == NULL)
+		tpm2key->policy = sk_TSSOPTPOLICY_new_null();
+	return __policy_add_policypcr(tpm2key->policy, pcr_sel);
+}
+
+bool
+tpm2key_add_authpolicy_policyauthorize(TSSPRIVKEY *tpm2key,
+				       const char *name,
+				       const TPML_PCR_SELECTION *pcr_sel,
+				       const TPM2B_PUBLIC *pub_key,
+				       const TPMT_SIGNATURE *signature,
+				       bool append)
+{
+	TSSAUTHPOLICY *ap = NULL;
+
+	ap = TSSAUTHPOLICY_new();
+	if (ap == NULL)
+		return false;
+
+	ap->name = ASN1_UTF8STRING_new();
+	ap->policy = sk_TSSOPTPOLICY_new_null();
+
+	ASN1_STRING_set(ap->name, name, strlen (name));
+
+	if (!__policy_add_policypcr(ap->policy, pcr_sel))
+		goto cleanup;
+
+	if (!__policy_add_policyauthorize(ap->policy, pub_key, signature))
+		goto cleanup;
+
+	if (tpm2key->authPolicy == NULL)
+		tpm2key->authPolicy = sk_TSSAUTHPOLICY_new_null();
+
+	/* Append the new authPolicy */
+	if (append)
+		sk_TSSAUTHPOLICY_push(tpm2key->authPolicy, ap);
+	else
+		sk_TSSAUTHPOLICY_unshift(tpm2key->authPolicy, ap);
+
+	return true;
+
+cleanup:
+	if (ap)
+		TSSAUTHPOLICY_free(ap);
+
+	return false;
+}
+
+bool
+tpm2key_read_file(const char *path, TSSPRIVKEY **tpm2key)
+{
+	TSSPRIVKEY *key = NULL;
+	buffer_t *bp;
+	const uint8_t *ptr;
+	char oid[128];
+
+	if (!(bp = buffer_read_file(path, 0)))
+		return false;
+
+	ptr = bp->data;
+	d2i_TSSPRIVKEY(&key, &ptr, bp->size);
+	if (key == NULL) {
+		error("%s does not seem to contain a valid TPM 2.0 Key\n", path);
+		return false;
+	}
+
+	buffer_free(bp);
+
+	/* check the content of the key */
+	if (OBJ_obj2txt(oid, sizeof(oid), key->type, 1) == 0) {
+		error("failed to parse object type\n");
+		goto error;
+	}
+
+	if (strcmp(OID_sealedData, oid) != 0) {
+		error("%s is not a sealed key in TPM 2.0 Key Format\n");
+		goto error;
+	}
+
+	if (key->emptyAuth != 1) {
+		error("emptyAuth is not TRUE\n");
+		goto error;
+	}
+
+	*tpm2key = key;
+
+	return true;
+error:
+	TSSPRIVKEY_free(key);
+
+	return false;
+}
+
+bool
+tpm2key_write_file(const char *path, TSSPRIVKEY *tpm2key)
+{
+	buffer_t write_buf;
+	unsigned char *der_buf = NULL;
+	int der_size;
+	bool ok = false;
+
+	der_size = i2d_TSSPRIVKEY(tpm2key, &der_buf);
+	if (der_size < 0) {
+		error("Failed to encode the key\n");
+		return false;
+	}
+
+	buffer_init_write(&write_buf, der_buf, der_size);
+	write_buf.wpos = der_size;
+	ok = buffer_write_file(path, &write_buf);
+
+	free(der_buf);
+
+	return ok;
+}
+
+/* Implement the TPM 2.0 Key File structures */
+IMPLEMENT_ASN1_FUNCTIONS(TSSOPTPOLICY)
+IMPLEMENT_ASN1_FUNCTIONS(TSSAUTHPOLICY)
+IMPLEMENT_ASN1_FUNCTIONS(TSSPRIVKEY)
+IMPLEMENT_PEM_write_bio(TSSPRIVKEY, TSSPRIVKEY, TSSPRIVKEY_PEM_STRING, TSSPRIVKEY)
+IMPLEMENT_PEM_read_bio(TSSPRIVKEY, TSSPRIVKEY, TSSPRIVKEY_PEM_STRING, TSSPRIVKEY)
+
+ASN1_SEQUENCE(TSSOPTPOLICY) = {
+	ASN1_EXP(TSSOPTPOLICY, CommandCode, ASN1_INTEGER, 0),
+	ASN1_EXP(TSSOPTPOLICY, CommandPolicy, ASN1_OCTET_STRING, 1)
+} ASN1_SEQUENCE_END(TSSOPTPOLICY)
+
+ASN1_SEQUENCE(TSSAUTHPOLICY) = {
+	ASN1_EXP_OPT(TSSAUTHPOLICY, name, ASN1_UTF8STRING, 0),
+	ASN1_EXP_SEQUENCE_OF(TSSAUTHPOLICY, policy, TSSOPTPOLICY, 1)
+} ASN1_SEQUENCE_END(TSSAUTHPOLICY)
+
+ASN1_SEQUENCE(TSSPRIVKEY) = {
+	ASN1_SIMPLE(TSSPRIVKEY, type, ASN1_OBJECT),
+	ASN1_EXP_OPT(TSSPRIVKEY, emptyAuth, ASN1_BOOLEAN, 0),
+	ASN1_EXP_SEQUENCE_OF_OPT(TSSPRIVKEY, policy, TSSOPTPOLICY, 1),
+	ASN1_EXP_OPT(TSSPRIVKEY, secret, ASN1_OCTET_STRING, 2),
+	ASN1_EXP_SEQUENCE_OF_OPT(TSSPRIVKEY, authPolicy, TSSAUTHPOLICY, 3),
+	ASN1_SIMPLE(TSSPRIVKEY, parent, ASN1_INTEGER),
+	ASN1_SIMPLE(TSSPRIVKEY, pubkey, ASN1_OCTET_STRING),
+	ASN1_SIMPLE(TSSPRIVKEY, privkey, ASN1_OCTET_STRING)
+} ASN1_SEQUENCE_END(TSSPRIVKEY)

--- a/src/tpm2key.h
+++ b/src/tpm2key.h
@@ -1,0 +1,43 @@
+/*
+ *   Copyright (C) 2023 SUSE LLC
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+#ifndef TPM2KEY_H
+#define TPM2KEY_H
+
+#include <openssl/asn1.h>
+#include <openssl/bio.h>
+#include "tpm2key-asn.h"
+
+bool	tpm2key_basekey(TSSPRIVKEY **tpm2key, const TPM2_HANDLE parent,
+			const TPM2B_PUBLIC *sealed_pub,
+			const TPM2B_PRIVATE *sealed_priv);
+
+bool	tpm2key_add_policy_policypcr(TSSPRIVKEY *tpm2key,
+			const TPML_PCR_SELECTION *pcr_sel);
+
+bool	tpm2key_add_authpolicy_policyauthorize(TSSPRIVKEY *tpm2key,
+			const char *name,
+			const TPML_PCR_SELECTION *pcr_sel,
+			const TPM2B_PUBLIC *pub_key,
+			const TPMT_SIGNATURE *signature,
+			bool append);
+
+bool	tpm2key_read_file(const char *path, TSSPRIVKEY **tpm2key);
+
+bool	tpm2key_write_file(const char *path, const TSSPRIVKEY *tpm2key);
+
+#endif


### PR DESCRIPTION
With '--key-format tpm2.0', 'seal-secret' outputs a sealed key in TPM 2.0 Key File format, and 'sign' prepends the new signed policy to the authPolicy sequence.

To seal a secret with a PCR policy against PCR 0,2,4,7:

  $ pcr-oracle \
	--key-format=tpm2.0 \
	--input secret \
	--output sealed-pcr.tpm \
	seal-secret 0,2,4,7

To seal a secret for an authorized policy:

  $ pcr-oracle \
	--key-format=tpm2.0 \
	--auth authorized.policy \
	--input secret \
	--output sealed-auth.tpm \
	seal-secret

To sign the policy against PCR 0,2,4,7 for sealed-auth.tpm:

  $ pcr-oracle \
	--key-format=tpm2.0 \
	--private-key policy-key.pem \
	--input sealed-auth.tpm \
	--output sealed-auth-signed.tpm \
	sign 0,2,4,7