### PR TITLE
Implement unseal for TPM 2.0 Key File

### DIFF
--- a/src/oracle.c
+++ b/src/oracle.c
@@ -1136,6 +1136,11 @@ main(int argc, char **argv)
 		break;
 
 	case ACTION_UNSEAL:
+		if (tpm2key_fmt) {
+			end_arguments(argc, argv);
+			break;
+		}
+
 		if (opt_authorized_policy) {
 			if (opt_rsa_public_key == NULL)
 				usage(1, "You need to specify the --public-key option when unsealing using an authorized policy\n");
@@ -1206,6 +1211,11 @@ main(int argc, char **argv)
 	}
 
 	if (action == ACTION_UNSEAL) {
+		if (tpm2key_fmt) {
+			/* input is the sealed secret, output is the cleartext */
+			if (!pcr_policy_unseal_tpm2key (opt_input, opt_output))
+				return 1;
+		} else
 		if (opt_authorized_policy) {
 			/* input is the sealed secret, output is the cleartext */
 			if (!pcr_authorized_policy_unseal_secret(pcr_selection, opt_authorized_policy, opt_pcr_policy, opt_rsa_public_key, opt_input, opt_output))

--- a/src/pcr.h
+++ b/src/pcr.h
@@ -73,5 +73,7 @@ extern bool		pcr_seal_secret(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
 				const char *input_path, const char *output_path);
 extern bool		pcr_unseal_secret(const tpm_pcr_selection_t *pcr_selection,
 				const char *input_path, const char *output_path);
+extern bool		pcr_policy_unseal_tpm2key(const char *input_path,
+				const char *output_path);
 
 #endif /* PCR_H */

--- a/test-tpm2key.sh
+++ b/test-tpm2key.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+#
+# This script needs to be run with root privilege
+#
+
+# TESTDIR=policy.test
+PCR_MASK=0,2,4,12
+
+pcr_oracle=pcr-oracle
+if [ -x pcr-oracle ]; then
+	pcr_oracle=$PWD/pcr-oracle
+fi
+
+function call_oracle {
+
+	echo "****************"
+	echo "pcr-oracle $*"
+	$pcr_oracle -d "$@"
+}
+
+if [ -z "$TESTDIR" ]; then
+	tmpdir=$(mktemp -d /tmp/pcrtestXXXXXX)
+	trap "cd / && rm -rf $tmpdir" 0 1 2 10 11 15
+
+	TESTDIR=$tmpdir
+fi
+
+trap "echo 'FAIL: command exited with error'; exit 1" ERR
+
+echo "This is super secret" >$TESTDIR/secret
+
+set -e
+cd $TESTDIR
+
+echo "Seal the secret with PCR policy"
+call_oracle \
+	--key-format tpm2.0 \
+	--from current \
+	--input secret \
+	--output sealed \
+	seal-secret $PCR_MASK
+
+echo "Unseal the sealed with PCR policy"
+call_oracle \
+	--key-format tpm2.0 \
+	--input sealed \
+	--output recovered \
+	unseal-secret
+
+if ! cmp secret recovered; then
+	echo "BAD: Unable to recover original secret"
+	echo "Secret:"
+	od -tx1c secret
+	echo "Recovered:"
+	od -tx1c recovered
+	exit 1
+else
+	echo "NICE: we were able to recover the original secret"
+fi
+
+rm -f sealed recovered
+
+call_oracle \
+	--rsa-generate-key \
+	--private-key policy-key.pem \
+	--auth authorized.policy \
+	create-authorized-policy $PCR_MASK
+
+call_oracle \
+	--private-key policy-key.pem \
+	--public-key policy-pubkey \
+	store-public-key
+
+call_oracle \
+	--key-format tpm2.0 \
+	--auth authorized.policy \
+	--input secret \
+	--output sealed \
+	seal-secret
+
+for attempt in first second; do
+	echo "Sign the set of PCRs we want to authorize"
+	call_oracle \
+		--key-format tpm2.0 \
+		--private-key policy-key.pem \
+		--from current \
+		--input sealed \
+		--output sealed-signed \
+		sign $PCR_MASK
+
+	echo "$attempt attempt to unseal the secret"
+	call_oracle \
+		--key-format tpm2.0 \
+		--input sealed-signed \
+		--output recovered \
+		unseal-secret
+
+	if ! cmp secret recovered; then
+		echo "BAD: Unable to recover original secret"
+		echo "Secret:"
+		od -tx1c secret
+		echo "Recovered:"
+		od -tx1c recovered
+		exit 1
+	else
+		echo "NICE: we were able to recover the original secret"
+	fi
+
+	if [ "$attempt" = "second" ]; then
+		break
+	fi
+
+	echo "Extend PCR 12. Unsealing should fail afterwards"
+	tpm2_pcrextend 12:sha256=21d2013e3081f1e455fdd5ba6230a8620c3cfc9a9c31981d857fe3891f79449e
+	rm -f recovered
+	call_oracle \
+		--key-format tpm2.0 \
+		--input sealed-signed \
+		--output recovered \
+		unseal-secret || true
+
+	if [ -s recovered ] && ! cmp secret recovered; then
+		echo "BAD: We were still able to recover the original secret. Something stinks"
+		exit 1
+	else
+		echo "GOOD: After changing a PCR, the secret can no longer be unsealed"
+	fi
+
+	echo "Now recreate the signed PCR policy"
+done


### PR DESCRIPTION
Look into the authPolicy or policy sequence to enforce the TPM2 policy commands to construct the policy digest. No matter how you seal the secret, to unseal a TPM 2.0 Key File:

  $ pcr-oracle \
	--key-format=tpm2.0 \
	--input sealed.tpm \
	--output recovered \
	unseal-secret

Also add test-tpm2key.sh to test the seal/unseal functions against TPM 2.0 Key files.