### PR TITLE
Skip the variable event with 0 length

### DIFF
--- a/src/efi-variable.c
+++ b/src/efi-variable.c
@@ -206,8 +206,15 @@ __tpm_event_efi_variable_rehash(const tpm_event_t *ev, const tpm_parsed_event_t 
 		file_data = runtime_read_efi_variable(var_name);
 	}
 
-	if (file_data == NULL)
+	if (file_data == NULL) {
+		if (parsed->efi_variable_event.len == 0) {
+			/* The content of the variable doesn't exist during the measurement
+			 * and is also not available at runtime. Let's skip this event.
+			 */
+			md = tpm_event_get_digest(ev, algo->openssl_name);
+		}
 		goto out;
+	}
 
 	buffers_to_free[num_buffers_to_free++] = file_data;
 


### PR DESCRIPTION
The UEFI firmware measures the Secure Boot variables such as PK, KEK, db, and dbx, etc. even when those variables are empty. An empty UEFI variable basically means it doesn't exist, so those variables won't exist in efivarfs, and this causes the error like this:

Error: Unable to read EFI variable "PK-8be4df61-93ca-11d2-aa0d-00e098032b8c"
Error: Failed to re-hash event 4 type EFI_VARIABLE_DRIVER_CONFIG

This commit ignores the file reading error when the variable length is 0 so that we can continue for the further actions like sealing.