### PR TITLE
Add the new parameter: policy-name

### DIFF
--- a/man/pcr-oracle.8.in
+++ b/man/pcr-oracle.8.in
@@ -368,6 +368,13 @@ using \fB--key-format=raw\fP.
 .IP
 Alternatively, it can read and write a format called \fBtpm2.0\fP which
 is becoming the preferred format used by grub.
+.TP
+.BI --policy-name " name
+For the tpm2.0 format, there is an extra field, Name, for the authorized
+polices. This option is only valid when sigining the sealded key in
+\fBtpm2.0\fP format. The \fBName\fP is optional and only used for display
+purposes. If the user doesn't specify a name, the default name is 'default'.
+
 .\" ##################################################################
 .\" # NOTES
 .\" ##################################################################
@@ -409,6 +416,7 @@ To sign the policy against PCR 0,2,4,7 for sealed-auth.tpm:
 .in +2
 # pcr-oracle \\
 	--key-format=tpm2.0 \\
+	--policy-name "sealing test" \\
 	--private-key policy-key.pem \\
 	--input sealed-auth.tpm \\
 	--output sealed-auth-signed.tpm \\

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -92,6 +92,7 @@ enum {
 	OPT_AUTHORIZED_POLICY,
 	OPT_PCR_POLICY,
 	OPT_KEY_FORMAT,
+	OPT_POLICY_NAME,
 };
 
 static struct option options[] = {
@@ -119,6 +120,7 @@ static struct option options[] = {
 	{ "authorized-policy",	required_argument,	0,	OPT_AUTHORIZED_POLICY },
 	{ "pcr-policy",		required_argument,	0,	OPT_PCR_POLICY },
 	{ "key-format",		required_argument,	0,	OPT_KEY_FORMAT },
+	{ "policy-name",	required_argument,	0,	OPT_POLICY_NAME },
 
 	{ NULL }
 };
@@ -1000,6 +1002,7 @@ main(int argc, char **argv)
 	char *opt_rsa_public_key = NULL;
 	bool opt_rsa_generate = false;
 	char *opt_key_format = NULL;
+	char *opt_policy_name = NULL;
 	bool tpm2key_fmt = false;
 	int c, exit_code = 0;
 
@@ -1076,6 +1079,9 @@ main(int argc, char **argv)
 			break;
 		case OPT_KEY_FORMAT:
 			opt_key_format = optarg;
+			break;
+		case OPT_POLICY_NAME:
+			opt_policy_name = optarg;
 			break;
 		case 'h':
 			usage(0, NULL);
@@ -1252,7 +1258,7 @@ main(int argc, char **argv)
 			return 1;
 	} else
 	if (action == ACTION_SIGN) {
-		if (!pcr_policy_sign(tpm2key_fmt, &pred->prediction, opt_rsa_private_key, opt_input, opt_output))
+		if (!pcr_policy_sign(tpm2key_fmt, &pred->prediction, opt_rsa_private_key, opt_input, opt_output, opt_policy_name))
 			return 1;
 	}
 

--- a/src/pcr-policy.c
+++ b/src/pcr-policy.c
@@ -1148,7 +1148,7 @@ cleanup:
  */
 bool
 pcr_policy_sign(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank, const char *rsakey_path,
-		const char *input_path, const char *output_path)
+		const char *input_path, const char *output_path, const char *policy_name)
 {
 	ESYS_CONTEXT *esys_context = tss_esys_context();
 	TPM2B_DIGEST *pcr_policy = NULL;
@@ -1180,8 +1180,11 @@ pcr_policy_sign(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank, const char *
 		goto out;
 
 	if (tpm2key) {
+		if (!policy_name)
+			policy_name = "default";
+
 		/* Prepend the signed policy */
-		if (!tpm2key_add_authpolicy_policyauthorize(tpm2key, "default",
+		if (!tpm2key_add_authpolicy_policyauthorize(tpm2key, policy_name,
 							    &pcr_sel, pub_key,
 							    signed_policy, false))
 			goto out;

--- a/src/pcr.h
+++ b/src/pcr.h
@@ -60,7 +60,7 @@ extern bool		pcr_authorized_policy_create(const tpm_pcr_selection_t *pcr_selecti
 extern bool		pcr_store_public_key(const char *rsakey_path, const char *output_path);
 extern bool		pcr_policy_sign(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
 				const char *rsakey_path, const char *input_path,
-				const char *output_path);
+				const char *output_path, const char *policy_name);
 extern bool		pcr_authorized_policy_seal_secret(const bool tpm2key_fmt,
 				const char *authorized_policy, const char *input_path,
 				const char *output_path);

--- a/test-tpm2key.sh
+++ b/test-tpm2key.sh
@@ -82,6 +82,7 @@ for attempt in first second; do
 	echo "Sign the set of PCRs we want to authorize"
 	call_oracle \
 		--key-format tpm2.0 \
+		--policy-name "authorized-policy-test" \
 		--private-key policy-key.pem \
 		--from current \
 		--input sealed \


### PR DESCRIPTION
This commit adds the new parameter, policy-name, to allow the user to specify the name of the authorized policy while signing the sealed key, and this could provide some hints about the content of the signed PCR. The name is only for the administrative use and doesn't provide any functionality.