### PR TITLE
Skip the leading operators when matching grub2 commands

### DIFF
--- a/src/oracle.c
+++ b/src/oracle.c
@@ -397,6 +397,7 @@ static bool
 __check_stop_event(tpm_event_t *ev, int type, const char *value, tpm_event_log_scan_ctx_t *ctx)
 {
 	const char *grub_arg = NULL;
+	const char *grub_cmd = NULL;
 	tpm_parsed_event_t *parsed;
 
 	switch (type) {
@@ -417,7 +418,11 @@ __check_stop_event(tpm_event_t *ev, int type, const char *value, tpm_event_log_s
 		if (!(grub_arg = parsed->grub_command.argv[0]))
 			return false;
 
-		return !strcmp(grub_arg, value);
+		grub_cmd = grub_arg;
+		while (grub_cmd != NULL && !isalpha(*grub_cmd))
+			grub_cmd++;
+
+		return !strcmp(grub_cmd, value);
 
 	case STOP_EVENT_GRUB_FILE:
 		if (ev->pcr_index != 9


### PR DESCRIPTION
After enabling TPM unsealing in grub2, the cryptomount command becomes:

if ! cryptomount -u $uuid --protector tpm2; then
    cryptomount -u $uuid
fi

In this case, '--stop-event="grub-command=cryptomount"' may not work since the measured command is '! cryptomount -u $uuid --protector tpm2'. This commit skips the leading operators so that we can match the real grub2 command.