### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/microconf/subst
+++ b/microconf/subst
@@ -8,7 +8,8 @@ function uc_build_sed_script {
 
 	__uc_sed_script="$__uc_scriptdir/sedscript"
 	if [ ! -f "$__uc_sed_script" ]; then
-		uc_date="$(date +'%B %-e, %Y')"
+		t=${SOURCE_DATE_EPOCH:-$(date +%s)}
+		uc_date="$(date -u -d @$t +'%B %-e, %Y')"
 		for varname in $(set | sed '/^uc_\(.*\)=.*/!d;s//\1/'); do
 			VARNAME=$(echo $varname | tr a-z A-Z)
 			echo "s|@$VARNAME@|$(eval echo \$uc_$varname)|"


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.
This date call only works with GNU date.

Also use UTC to be independent of timezone.

Locales still can cause `%B` to vary. ISO 8601 date format would help there.