### PR TITLE
Support more RSA key sizes

### DIFF
--- a/man/pcr-oracle.8.in
+++ b/man/pcr-oracle.8.in
@@ -270,6 +270,20 @@ To perform a TPM self-test, simply execute \fBpcr-oracle\fP like this:
 The reason this subcommand exists is that it allows an installer to
 set up full disk encryption without having to pull in all of tpm-tools.
 .\" ##################################################################
+.\" # RSA key size test
+.\" ##################################################################
+.SS TPM RSA key size test
+To perform a TPM RSA key size test, simply execute \fBpcr-oracle\fP like
+this:
+.P
+.nf
+.in +2
+# pcr-oracle --rsa-bits 2048 rsa-test
+.fi
+.P
+This subcommand allows the external programs, such as fde-tools, to find
+out the largest supported RSA key size.
+.\" ##################################################################
 .\" # OPTIONS
 .\" ##################################################################
 .SH OPTIONS
@@ -354,6 +368,12 @@ what \fBopenssl genrsa\fP does; the only reason this switch exists is
 that it may save you from increasing the footprint of your installed
 system (by not having to install the openssl command line utilities,
 for example).
+.TP
+.BI --rsa-bits " bits
+By default, RSA 2048 is used as the algorithm to create the public and
+private key and configure the storage root key(SRK) in TPM. This option
+allows the user to specify the larger RSA key size. The supported key
+sizes are: 2048, 3072, and 4096 bits.
 .TP
 .BI --tpm-eventlog " path
 By default, the tool will read the current TPM event log. It is possible

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -87,6 +87,7 @@ enum {
 	OPT_RSA_PRIVATE_KEY,
 	OPT_RSA_PUBLIC_KEY,
 	OPT_RSA_GENERATE_KEY,
+	OPT_RSA_BITS,
 	OPT_INPUT,
 	OPT_OUTPUT,
 	OPT_AUTHORIZED_POLICY,
@@ -115,6 +116,7 @@ static struct option options[] = {
 	{ "private-key",	required_argument,	0,	OPT_RSA_PRIVATE_KEY },
 	{ "public-key",		required_argument,	0,	OPT_RSA_PUBLIC_KEY },
 	{ "rsa-generate-key",	no_argument,		0,	OPT_RSA_GENERATE_KEY },
+	{ "rsa-bits",		required_argument,	0,	OPT_RSA_BITS },
 	{ "input",		required_argument,	0,	OPT_INPUT },
 	{ "output",		required_argument,	0,	OPT_OUTPUT },
 	{ "authorized-policy",	required_argument,	0,	OPT_AUTHORIZED_POLICY },
@@ -1006,9 +1008,11 @@ main(int argc, char **argv)
 	char *opt_rsa_private_key = NULL;
 	char *opt_rsa_public_key = NULL;
 	bool opt_rsa_generate = false;
+	char *opt_rsa_bits = NULL;
 	char *opt_key_format = NULL;
 	char *opt_policy_name = NULL;
 	bool tpm2key_fmt = false;
+	unsigned int rsa_bits = 2048;
 	int c, exit_code = 0;
 
 	while ((c = getopt_long(argc, argv, "dhA:CF:LSZ", options, NULL)) != EOF) {
@@ -1070,6 +1074,9 @@ main(int argc, char **argv)
 		case OPT_RSA_GENERATE_KEY:
 			opt_rsa_generate = true;
 			break;
+		case OPT_RSA_BITS:
+			opt_rsa_bits = optarg;
+			break;
 		case OPT_INPUT:
 			opt_input = optarg;
 			break;
@@ -1105,6 +1112,19 @@ main(int argc, char **argv)
 
 	if (opt_create_testcase)
 		runtime_record_testcase(testcase_alloc(opt_create_testcase));
+
+	if (opt_rsa_bits) {
+		if (strcmp(opt_rsa_bits, "2048") == 0)
+			rsa_bits = 2048;
+		else
+		if (strcmp(opt_rsa_bits, "3072") == 0)
+			rsa_bits = 3072;
+		else
+		if (strcmp(opt_rsa_bits, "4096") == 0)
+			rsa_bits = 4096;
+		else
+			fatal("Unsupported RSA bits: %s\n", opt_rsa_bits);
+	}
 
 	if (!opt_key_format || !strcasecmp(opt_key_format, "raw"))
 		tpm2key_fmt = false;
@@ -1179,6 +1199,8 @@ main(int argc, char **argv)
 		fatal("Action %u not implemented", action);
 	}
 
+	set_srk_rsa_bits (rsa_bits);
+
 	if (action == ACTION_SELFTEST) {
 		if (!tpm_selftest(true))
 			return 1;
@@ -1195,7 +1217,7 @@ main(int argc, char **argv)
 			tpm_rsa_key_t *key;
 
 			infomsg("Generating new RSA key\n");
-			if (!(key = tpm_rsa_generate(2048)))
+			if (!(key = tpm_rsa_generate(rsa_bits)))
 				return 1;
 			if (!tpm_rsa_key_write_private(opt_rsa_private_key, key))
 				return 1;

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -43,6 +43,7 @@ enum {
 	ACTION_UNSEAL,
 	ACTION_SIGN,
 	ACTION_SELFTEST,
+	ACTION_RSATEST,
 };
 
 enum {
@@ -944,6 +945,7 @@ get_action_argument(int argc, char **argv)
 		{ "unseal-secret",		ACTION_UNSEAL	},
 		{ "sign",			ACTION_SIGN	},
 		{ "self-test",			ACTION_SELFTEST	},
+		{ "rsa-test",			ACTION_RSATEST	},
 
 		{ NULL, 0 },
 	};
@@ -1195,8 +1197,22 @@ main(int argc, char **argv)
 		end_arguments(argc, argv);
 		break;
 
+	case ACTION_RSATEST:
+		end_arguments(argc, argv);
+		break;
+
 	default:
 		fatal("Action %u not implemented", action);
+	}
+
+	if (action == ACTION_RSATEST) {
+		if (tpm_rsa_bits_test(rsa_bits)) {
+			infomsg("RSA %u supported\n", rsa_bits);
+			return 0;
+		} else {
+			infomsg("RSA %u unsupported\n", rsa_bits);
+			return 1;
+		}
 	}
 
 	set_srk_rsa_bits (rsa_bits);

--- a/src/oracle.h
+++ b/src/oracle.h
@@ -26,6 +26,7 @@
 extern bool		ima_is_active(void);
 extern buffer_t *	platform_read_shim_vendor_cert(void);
 extern bool		tpm_selftest(bool fulltest);
+extern bool		tpm_rsa_bits_test(unsigned int rsa_bits);
 
 #endif /* PCR_ORACLE_H */
 

--- a/src/pcr-policy.c
+++ b/src/pcr-policy.c
@@ -40,7 +40,7 @@
 #include "config.h"
 #include "tpm2key.h"
 
-static const TPM2B_PUBLIC SRK_template = {
+static TPM2B_PUBLIC SRK_template = {
 	.size = sizeof(TPMT_PUBLIC),
 	.publicArea = {
 		.type = TPM2_ALG_RSA,
@@ -84,6 +84,11 @@ static const TPM2B_PUBLIC seal_public_template = {
             }
         };
 
+void
+set_srk_rsa_bits (const unsigned int rsa_bits)
+{
+	SRK_template.publicArea.parameters.rsaDetail.keyBits = rsa_bits;
+}
 
 static inline const tpm_evdigest_t *
 tpm_evdigest_from_TPM2B_DIGEST(const TPM2B_DIGEST *td, tpm_evdigest_t *result, const tpm_algo_info_t *algo_info)

--- a/src/pcr.h
+++ b/src/pcr.h
@@ -75,5 +75,4 @@ extern bool		pcr_unseal_secret(const tpm_pcr_selection_t *pcr_selection,
 				const char *input_path, const char *output_path);
 extern bool		pcr_policy_unseal_tpm2key(const char *input_path,
 				const char *output_path);
-
 #endif /* PCR_H */

--- a/src/pcr.h
+++ b/src/pcr.h
@@ -39,6 +39,7 @@ typedef struct tpm_pcr_selection {
 	const tpm_algo_info_t *	algo_info;
 } tpm_pcr_selection_t;
 
+extern void		set_srk_rsa_bits (const unsigned int rsa_bits);
 extern void		pcr_bank_initialize(tpm_pcr_bank_t *bank, unsigned int pcr_mask, const tpm_algo_info_t *algo);
 extern bool		pcr_bank_wants_pcr(tpm_pcr_bank_t *bank, unsigned int index);
 extern void		pcr_bank_mark_valid(tpm_pcr_bank_t *bank, unsigned int index);

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -264,7 +264,7 @@ rsa_pubkey_alloc(const BIGNUM *n, const BIGNUM *e, const char *pathname)
 	unsigned int key_bits;
 
 	key_bits = BN_num_bytes(n) * 8;
-	if (key_bits != 1024 && key_bits != 2048 && key_bits != 4096) {
+	if (key_bits != 1024 && key_bits != 2048 && key_bits != 3072 && key_bits != 4096) {
 		error("%s: unsupported RSA key size (%u bits)\n", pathname, key_bits);
 		return NULL;
 	}


### PR DESCRIPTION
For the users require the better security settings,  a RSA key size larger than 2048 bits may be desired. To support the more RSA key size, '--rsa-bits' is introduced to specify the key size. An additional subcommand, rsa-test, is also added to allow the user to check the supported RSA key sizes in the TPM chip.