### PR TITLE
Collection of fixes

### DIFF
--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -810,7 +810,7 @@ __tpm_event_systemd_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *pars
 	snprintf(initrd, sizeof(initrd), "initrd=%s %s",
 		 entry_list.entries[0].initrd, entry_list.entries[0].options);
 
-	len = (strlen(initrd) + 1) << 2;
+	len = (strlen(initrd) + 1) << 1;
 	assert(len <= sizeof(initrd_utf16));
 	__convert_to_utf16le(initrd, strlen(initrd) + 1, initrd_utf16, len);
 

--- a/src/sd-boot.c
+++ b/src/sd-boot.c
@@ -44,10 +44,10 @@ read_entry_token()
 	if (fgets(id, SDB_LINE_MAX, fp))
 		id[strcspn(id, "\n")] = 0;
 
+	fclose(fp);
 	return id;
 
 fail:
-	fclose(fp);
 	return NULL;
 }
 
@@ -91,6 +91,7 @@ read_os_release(const char *key)
 		}
 		id[k] = '\0';
 
+		fclose(fp);
 		return id;
 
 next_line:
@@ -98,7 +99,6 @@ next_line:
 	}
 
 fail:
-	fclose(fp);
 	return NULL;
 }
 
@@ -116,10 +116,10 @@ read_machine_id()
 	if (fgets(id, SDB_LINE_MAX, fp))
 		id[strcspn(id, "\n")] = 0;
 
+	fclose(fp);
 	return id;
 
 fail:
-	fclose(fp);
 	return NULL;
 }
 
@@ -161,10 +161,10 @@ read_entry(sdb_entry_data_t *result)
 		strncpy(dest, &line[index], strlen(&line[index]) - 1);
 	}
 
+	fclose(fp);
 	return true;
 
 fail:
-	fclose(fp);
 	return false;
 }
 

--- a/src/sd-boot.c
+++ b/src/sd-boot.c
@@ -277,10 +277,27 @@ entrycmp(const void *va, const void *vb)
 	return -result;
 }
 
+static bool
+exists_efi_dir(const char *path)
+{
+	DIR *d = NULL;
+	char full_path[PATH_MAX];
+
+	if (path == NULL)
+		return false;
+
+	snprintf(full_path, PATH_MAX, "/boot/efi/%s", path);
+	if (!(d = opendir(full_path)))
+		return false;
+
+	closedir(d);
+	return true;
+}
+
 bool
 sdb_get_entry_list(sdb_entry_list_t *result)
 {
-	// const char *id = NULL;
+	const char *id = NULL;
 	const char *image_id = NULL;
 	const char *machine_id = NULL;
 	const char *token_id = NULL;
@@ -292,16 +309,19 @@ sdb_get_entry_list(sdb_entry_list_t *result)
 
 	/* All IDs are optional (cannot be present), except machine_id */
 	token_id = read_entry_token();
-	// id = read_os_release("ID");
+	id = read_os_release("ID");
 	image_id = read_os_release("IMAGE_ID");
 	if (!(machine_id = read_machine_id()))
 		goto fail;
 
-	/* The order is not correct (ID is not used), but is how
-	 * sdbootutil seems to work */
-	if (token_id == NULL && image_id != NULL)
-		token_id = image_id;
-	if (token_id == NULL && machine_id != NULL)
+	/* The order is not correct, and it is using some heuristics
+	 * to find the correct prefix.  Other tools like sdbootutil
+	 * seems to use parameters to decide */
+	if (token_id == NULL && exists_efi_dir(id))
+		token_id = id;
+	if (token_id == NULL && exists_efi_dir(image_id))
+		token_id = id;
+	if (token_id == NULL && exists_efi_dir(machine_id))
 		token_id = machine_id;
 
 	if (!(d = opendir(path))) {
@@ -326,10 +346,9 @@ sdb_get_entry_list(sdb_entry_list_t *result)
 
 	qsort(result->entries, result->num_entries, sizeof(result->entries[0]), entrycmp);
 
+	closedir(d);
 	return true;
 
 fail:
-	closedir(d);
 	return false;
 }
-


### PR DESCRIPTION
* Close the files before returning, not when there is a fail (and the file handler will be NULL)
* Find EFI token in a different order, and check that the directory exist to mark the end of the search
* Correct the length calculation for the UTF16 string