### PR TITLE
Target platform

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -30,6 +30,7 @@ ORACLE_SRCS	= oracle.c \
 		  platform.c \
 		  testcase.c \
 		  bufparser.c \
+		  store.c \
 		  util.c \
 		  sd-boot.c
 ORACLE_OBJS	= $(addprefix build/,$(patsubst %.c,%.o,$(ORACLE_SRCS)))

--- a/Makefile.in
+++ b/Makefile.in
@@ -3,8 +3,9 @@ PKGNAME		= pcr-oracle-$(VERSION)
 
 CCOPT		= -O0 -g
 FIRSTBOOTDIR	= /usr/share/jeos-firstboot
-CFLAGS		= -Wall -I /usr/include/tss2 $(CCOPT)
+CFLAGS		= -Wall @TSS2_ESYS_CFLAGS@ @JSON_CFLAGS@ $(CCOPT)
 TSS2_LINK	= -ltss2-esys -ltss2-tctildr -ltss2-rc -ltss2-mu -lcrypto
+JSON_LINK	= -L@JSON_LIBDIR@ @JSON_LIBS@
 TOOLS		= pcr-oracle
 
 MANDIR		= @MANDIR@
@@ -51,7 +52,7 @@ clean:
 	rm -rf build
 
 pcr-oracle: $(ORACLE_OBJS)
-	$(CC) -o $@ $(ORACLE_OBJS) $(TSS2_LINK)
+	$(CC) -o $@ $(ORACLE_OBJS) $(TSS2_LINK) $(JSON_LINK)
 
 build/%.o: src/%.c
 	@mkdir -p build

--- a/configure
+++ b/configure
@@ -14,6 +14,7 @@
 # microconf:begin
 # version 0.4.6
 # require libtss2
+# require json
 # disable debug-authenticode
 # microconf:end
 

--- a/man/pcr-oracle.8.in
+++ b/man/pcr-oracle.8.in
@@ -199,8 +199,38 @@ supports this via its \fBstore-public-key\fP subcommand:
 This command will read the RSA private key from the PEM file,
 and write the public key as a \fBTPM2B_PUBLIC\fP object to
 the indicated output file \fBpolicy-pubkey\fP.
+.P
+Alternatively, if you want the public key to be stored as PEM formatted
+key, simply specify the file name of the public key with a \fB.pem\fP
+extension:
+.P
+.nf
+.in +2
+# pcr-oracle \\
+.br
+        --private-key policy-key.pem \\
+.br
+        --public-key policy-pubkey.pem \\
+.br
+        store-public-key
+.fi
+.P
+For details, please see section \fBRSA Key File Formats\fP.
 .\" ##################################################################
-.\" # New key format
+.\" # Supporting different key file format
+.\" ##################################################################
+.SS RSA Key File Formats
+By default, \fBpcr-oracle\fP stores private RSA keys as PEM files and
+public RSA keys in native TPM encoded format. This behavior can be tuned,
+however. When it detects a file name that has a \fB.pem\fP extension, it
+will automatically assume that the caller expects the file to be in PEM
+format.
+.P
+In addition, you can explicitly force a specific file format by
+prefixing the entire path by either \fBpem:\fP opr \fBnative:\fP,
+respectively.
+.\" ##################################################################
+.\" # New policy file format
 .\" ##################################################################
 .SS Using the TPM2.0 policy file format
 By default, \fBpcr-oracle\fP writes the policy and key files (which are
@@ -367,9 +397,11 @@ the policy will be read from this location.
 .TP
 .BI --private-key " path
 Specify the RSA secret key to be used with authorized policies.
+For notes on the file format, please see section \fBRSA Key File Formats\fP.
 .TP
 .BI --public-key " path
 Specify an RSA public key to be used with authorized policies.
+For notes on the file format, please see section \fBRSA Key File Formats\fP.
 .TP
 .BI --rsa-generate-key
 When used while creating an authorized policy, a sign or when storing

--- a/microconf/stage1/03-json
+++ b/microconf/stage1/03-json
@@ -1,0 +1,12 @@
+uc_add_option_with libjson
+uc_with_libjson=detect
+
+uc_add_help <<EOH
+
+
+  Override libjson detection
+        --with-libjson=VERSION
+        --without-libjson
+ 
+EOH
+

--- a/microconf/stage3/05-json
+++ b/microconf/stage3/05-json
@@ -1,0 +1,7 @@
+##################################################################
+# libjson version
+##################################################################
+if [ -z "$uc_with_libjson" -o "$uc_with_libjson" = "detect" ]; then
+	uc_pkg_config_check_package json
+fi
+

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -97,6 +97,7 @@ enum {
 	OPT_KEY_FORMAT,
 	OPT_POLICY_NAME,
 	OPT_POLICY_FORMAT,
+	OPT_TARGET_PLATFORM,
 };
 
 static struct option options[] = {
@@ -127,6 +128,7 @@ static struct option options[] = {
 	{ "key-format",		required_argument,	0,	OPT_KEY_FORMAT },
 	{ "policy-name",	required_argument,	0,	OPT_POLICY_NAME },
 	{ "policy-format",	required_argument,	0,	OPT_POLICY_FORMAT },
+	{ "target-platform",	required_argument,	0,	OPT_TARGET_PLATFORM },
 
 	{ NULL }
 };
@@ -1017,11 +1019,10 @@ main(int argc, char **argv)
 	stored_key_t *opt_rsa_public_key = NULL;
 	bool opt_rsa_generate = false;
 	char *opt_rsa_bits = NULL;
-	char *opt_key_format = NULL;
 	char *opt_policy_name = NULL;
-	char *opt_policy_format = NULL;
-	bool tpm2key_fmt = false;
-	int systemd_json = false;
+	char *opt_target_platform = NULL;
+	const target_platform_t *target;
+	unsigned int action_flags = 0;
 	unsigned int rsa_bits = 2048;
 	int c, exit_code = 0;
 
@@ -1102,13 +1103,18 @@ main(int argc, char **argv)
 			opt_pcr_policy = optarg;
 			break;
 		case OPT_KEY_FORMAT:
-			opt_key_format = optarg;
+			warning("Detected --key-format option; please use --target-platform instead\n");
+			opt_target_platform = optarg;
 			break;
 		case OPT_POLICY_NAME:
 			opt_policy_name = optarg;
 			break;
 		case OPT_POLICY_FORMAT:
-			opt_policy_format = optarg;
+			warning("Detected --policy-format option; please use --target-platform instead\n");
+			opt_target_platform = optarg;
+			break;
+		case OPT_TARGET_PLATFORM:
+			opt_target_platform = optarg;
 			break;
 		case 'h':
 			usage(0, NULL);
@@ -1141,21 +1147,10 @@ main(int argc, char **argv)
 			fatal("Unsupported RSA bits: %s\n", opt_rsa_bits);
 	}
 
-	if (!opt_key_format || !strcasecmp(opt_key_format, "raw"))
-		tpm2key_fmt = false;
-	else
-	if (!strcasecmp(opt_key_format, "tpm2.0"))
-		tpm2key_fmt = true;
-	else
-		fatal("Unsupported key format \"%s\"\n", opt_key_format);
-
-	if (!opt_policy_format || !strcasecmp(opt_policy_format, "grub2"))
-		systemd_json = false;
-	else
-	if (!strcasecmp(opt_policy_format, "systemd"))
-		systemd_json = true;
-	else
-		fatal("Unsupported policy format \"%s\"\n", opt_policy_format);
+	if (opt_target_platform == NULL)
+		opt_target_platform = "oldgrub"; /* we should probably change this to tpm2.0 now */
+	if ((target = pcr_get_target_platform(opt_target_platform)) == NULL)
+		fatal("Unsupported target platform %s\n", opt_target_platform);
 
 	/* Validate options */
 	switch (action) {
@@ -1190,26 +1185,28 @@ main(int argc, char **argv)
 		break;
 
 	case ACTION_UNSEAL:
-		if (tpm2key_fmt) {
-			end_arguments(argc, argv);
-			break;
+		action_flags = target_platform_unseal_flags(target);
+		if (action_flags & PLATFORM_OPTIONAL_PCR_POLICY) {
+			if (opt_rsa_public_key == NULL && opt_pcr_policy)
+				usage(1, "You need to specify the --public-key option when unsealing using an authorized policy\n");
+			if (opt_pcr_policy == NULL && opt_rsa_public_key)
+				usage(1, "You need to specify the --pcr-policy option when unsealing using an authorized policy\n");
 		}
 
-		if (opt_rsa_public_key == NULL && opt_pcr_policy)
-			usage(1, "You need to specify the --public-key option when unsealing using an authorized policy\n");
-		if (opt_pcr_policy == NULL && opt_rsa_public_key)
-			usage(1, "You need to specify the --pcr-policy option when unsealing using an authorized policy\n");
-		pcr_selection = get_pcr_selection_argument(argc, argv, opt_algo);
+		if ((action_flags & PLATFORM_NEED_INPUT_FILE) && !opt_input)
+			usage(1, "You need to specify an input file via --input when unsealing a secret");
+		if ((action_flags & PLATFORM_NEED_OUTPUT_FILE) && !opt_output)
+			usage(1, "You need to specify an output file via --output when unsealing a secret");
+		if (action_flags & PLATFORM_NEED_PCR_SELECTION)
+			pcr_selection = get_pcr_selection_argument(argc, argv, opt_algo);
 		end_arguments(argc, argv);
 		break;
 
 	case ACTION_SIGN:
 		if (opt_rsa_private_key == NULL)
 			usage(1, "You need to specify the --private-key option when signing a policy\n");
-		if (systemd_json && opt_output == NULL)
-			usage(1, "You need to specify the --output option when signing a systemd policy\n");
-		if (tpm2key_fmt && opt_input == NULL)
-			usage(1, "You need to specify the --input option when signing a policy into a TPM 2.0 Key file\n");
+		if (opt_output == NULL)
+			usage(1, "You need to specify the --output option when signing a policy\n");
 
 		pcr_selection = get_pcr_selection_argument(argc, argv, opt_algo);
 		end_arguments(argc, argv);
@@ -1278,26 +1275,15 @@ main(int argc, char **argv)
 	/* When sealing a secret against an authorized policy, there's no need to
 	 * mess around with PCR values. That's the beauty of it... */
 	if (action == ACTION_SEAL && opt_authorized_policy) {
-		if (!pcr_authorized_policy_seal_secret(tpm2key_fmt, opt_authorized_policy, opt_input, opt_output))
+		if (!pcr_authorized_policy_seal_secret(target, opt_authorized_policy, opt_input, opt_output))
 			return 1;
 
 		return 0;
 	}
 
 	if (action == ACTION_UNSEAL) {
-		if (tpm2key_fmt) {
-			/* input is the sealed secret, output is the cleartext */
-			if (!pcr_policy_unseal_tpm2key (opt_input, opt_output))
-				return 1;
-		} else
-		if (opt_rsa_public_key) {
-			/* input is the sealed secret, output is the cleartext */
-			if (!pcr_authorized_policy_unseal_secret(pcr_selection, opt_pcr_policy, opt_rsa_public_key, opt_input, opt_output))
-				return 1;
-		} else {
-			if (!pcr_unseal_secret(pcr_selection, opt_input, opt_output))
-				return 1;
-		}
+		if (!pcr_unseal_secret_new(target, pcr_selection, opt_pcr_policy, opt_rsa_public_key, opt_input, opt_output))
+			return 1;
 
 		return 0;
 	}
@@ -1325,18 +1311,12 @@ main(int argc, char **argv)
 			predictor_report(pred);
 	} else
 	if (action == ACTION_SEAL) {
-		/* TBD - seal secret against a set of PCR values */
-		if (!pcr_seal_secret(tpm2key_fmt, &pred->prediction, opt_input, opt_output))
+		if (!pcr_seal_secret(target, &pred->prediction, opt_input, opt_output))
 			return 1;
 	} else
 	if (action == ACTION_SIGN) {
-		if (systemd_json) {
-			if (!pcr_policy_sign_systemd(&pred->prediction, opt_rsa_private_key, opt_output))
-				return 1;
-		} else {
-			if (!pcr_policy_sign(tpm2key_fmt, &pred->prediction, opt_rsa_private_key, opt_input, opt_output, opt_policy_name))
-				return 1;
-		}
+		if (!pcr_policy_sign(target, &pred->prediction, opt_rsa_private_key, opt_input, opt_output, opt_policy_name))
+			return 1;
 	}
 
 	return exit_code;

--- a/src/pcr-policy.c
+++ b/src/pcr-policy.c
@@ -40,6 +40,27 @@
 #include "tpm.h"
 #include "config.h"
 #include "tpm2key.h"
+#include "sd-boot.h"
+
+struct target_platform {
+        const char *    name;
+	unsigned int	unseal_flags;
+
+        bool            (*write_sealed_secret)(const char *pathname,
+					const TPML_PCR_SELECTION *pcr_sel,
+					const TPM2B_PRIVATE *sealed_private,
+					const TPM2B_PUBLIC *sealed_public);
+        bool            (*write_signed_policy)(const char *input_path, const char *output_path,
+					const char *policy_name,
+					const tpm_pcr_bank_t *bank,
+					const TPM2B_DIGEST *pcr_policy,
+					const tpm_rsa_key_t *signing_key,
+					const TPMT_SIGNATURE *signed_policy);
+	bool		(*unseal_secret)(const char *input_path, const char *output_path,
+					const tpm_pcr_selection_t *pcr_selection,
+					const char *signed_policy_path,
+					const stored_key_t *public_key_file);
+};
 
 static TPM2B_PUBLIC SRK_template = {
 	.size = sizeof(TPMT_PUBLIC),
@@ -628,7 +649,7 @@ esys_create(ESYS_CONTEXT *esys_context,
 }
 
 static bool
-esys_seal_secret(const bool tpm2key_fmt, ESYS_CONTEXT *esys_context,
+esys_seal_secret(const target_platform_t *platform, ESYS_CONTEXT *esys_context,
 		 TPM2B_DIGEST *policy, const TPML_PCR_SELECTION *pcr_sel,
 		 const char *input_path, const char *output_path)
 {
@@ -636,7 +657,6 @@ esys_seal_secret(const bool tpm2key_fmt, ESYS_CONTEXT *esys_context,
 	TPM2B_PRIVATE *sealed_private = NULL;
 	TPM2B_PUBLIC *sealed_public = NULL;
 	ESYS_TR srk_handle = ESYS_TR_NONE;
-	TSSPRIVKEY *tpm2key = NULL;
 	bool ok = false;
 
 	if (!(secret = read_secret(input_path)))
@@ -650,17 +670,7 @@ esys_seal_secret(const bool tpm2key_fmt, ESYS_CONTEXT *esys_context,
 	if (!esys_create(esys_context, srk_handle, policy, secret, &sealed_private, &sealed_public))
 		goto cleanup;
 
-	if (tpm2key_fmt) {
-		if (!tpm2key_basekey(&tpm2key, TPM2_RH_OWNER, sealed_public, sealed_private))
-			goto cleanup;
-
-		if (pcr_sel && !tpm2key_add_policy_policypcr(tpm2key, pcr_sel))
-			goto cleanup;
-
-		ok = tpm2key_write_file(output_path, tpm2key);
-	} else
-		ok = write_sealed_secret(output_path, sealed_public, sealed_private);
-
+	ok = platform->write_sealed_secret(output_path, pcr_sel, sealed_private, sealed_public);
 	if (ok)
 		infomsg("Sealed secret written to %s\n", output_path?: "(standard output)");
 
@@ -671,8 +681,6 @@ cleanup:
 		free(sealed_public);
 	if (secret)
 		free_secret(secret);
-	if (tpm2key)
-		TSSPRIVKEY_free(tpm2key);
 
 	esys_flush_context(esys_context, &srk_handle);
 	return ok;
@@ -1004,7 +1012,7 @@ pcr_store_public_key(const stored_key_t *private_key_file, const stored_key_t *p
 }
 
 bool
-pcr_seal_secret(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
+pcr_seal_secret(const target_platform_t *platform, const tpm_pcr_bank_t *bank,
 		const char *input_path, const char *output_path)
 {
 	ESYS_CONTEXT *esys_context = tss_esys_context();
@@ -1018,15 +1026,15 @@ pcr_seal_secret(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
 	if (!pcr_bank_to_selection(&pcr_sel, bank))
 		return false;
 
-	ok = esys_seal_secret(tpm2key_fmt, esys_context, pcr_policy, &pcr_sel,
+	ok = esys_seal_secret(platform, esys_context, pcr_policy, &pcr_sel,
 			      input_path, output_path);
 
 	free(pcr_policy);
 	return ok;
 }
 
-bool
-pcr_unseal_secret(const tpm_pcr_selection_t *pcr_selection, const char *input_path, const char *output_path)
+static bool
+pcr_unseal_secret_pcr(const tpm_pcr_selection_t *pcr_selection, const char *input_path, const char *output_path)
 {
 	ESYS_CONTEXT *esys_context = tss_esys_context();
 	tpm_pcr_bank_t pcr_current_bank;
@@ -1079,7 +1087,7 @@ pcr_authorized_policy_create(const tpm_pcr_selection_t *pcr_selection, const sto
 }
 
 bool
-pcr_authorized_policy_seal_secret(const bool tpm2key_fmt, const char *authpolicy_path,
+pcr_authorized_policy_seal_secret(const target_platform_t *platform, const char *authpolicy_path,
 				  const char *input_path, const char *output_path)
 {
 	ESYS_CONTEXT *esys_context = tss_esys_context();
@@ -1089,7 +1097,7 @@ pcr_authorized_policy_seal_secret(const bool tpm2key_fmt, const char *authpolicy
 	if (!(authorized_policy = read_digest(authpolicy_path)))
 		return false;
 
-	ok = esys_seal_secret(tpm2key_fmt, esys_context, authorized_policy, NULL,
+	ok = esys_seal_secret(platform, esys_context, authorized_policy, NULL,
 			      input_path, output_path);
 	free(authorized_policy);
 	return ok;
@@ -1146,7 +1154,7 @@ cleanup:
  * expected PCR values, and signing the resulting digest.
  */
 bool
-pcr_policy_sign(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
+pcr_policy_sign(const target_platform_t *platform, const tpm_pcr_bank_t *bank,
 		const stored_key_t *private_key_file,
 		const char *input_path, const char *output_path, const char *policy_name)
 {
@@ -1155,23 +1163,15 @@ pcr_policy_sign(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
 	tpm_rsa_key_t *rsa_key = NULL;
 	TPM2B_PUBLIC *pub_key = NULL;
 	TPMT_SIGNATURE *signed_policy = NULL;
-	TSSPRIVKEY *tpm2key = NULL;
-	TPML_PCR_SELECTION pcr_sel;
 	bool okay = false;
+
+	if (platform->write_signed_policy == NULL) {
+		error("Platform %s does not support signing policies yet\n", platform->name);
+		goto out;
+	}
 
 	if (!(rsa_key = stored_key_read_rsa_private(private_key_file)))
 		goto out;
-
-	if (tpm2key_fmt) {
-		if (!(pub_key = tpm_rsa_key_to_tss2(rsa_key)))
-			goto out;
-
-		if (!tpm2key_read_file(input_path, &tpm2key))
-			goto out;
-
-		if (!pcr_bank_to_selection(&pcr_sel, bank))
-			goto out;
-	}
 
 	if (!(pcr_policy = __pcr_policy_make(esys_context, bank)))
 		goto out;
@@ -1179,24 +1179,11 @@ pcr_policy_sign(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
 	if (!__pcr_policy_sign(rsa_key, pcr_policy, &signed_policy))
 		goto out;
 
-	if (tpm2key) {
-		if (!policy_name)
-			policy_name = "default";
-
-		/* Prepend the signed policy */
-		if (!tpm2key_add_authpolicy_policyauthorize(tpm2key, policy_name,
-							    &pcr_sel, pub_key,
-							    signed_policy, false))
-			goto out;
-
-		if (!tpm2key_write_file(output_path, tpm2key))
-			goto out;
-	} else {
-		if (!write_signature(output_path, signed_policy))
-			goto out;
-	}
-	infomsg("Signed PCR policy written to %s\n", output_path?: "(standard output)");
-	okay = true;
+	okay = platform->write_signed_policy(input_path, output_path,
+			policy_name, bank, pcr_policy,
+			rsa_key, signed_policy);
+	if (okay)
+		infomsg("Signed PCR policy written to %s\n", output_path?: "(standard output)");
 
 out:
 	if (pcr_policy)
@@ -1207,8 +1194,6 @@ out:
 		free(pub_key);
 	if (rsa_key)
 		tpm_rsa_key_free(rsa_key);
-	if (tpm2key)
-		TSSPRIVKEY_free(tpm2key);
 
 	return okay;
 }
@@ -1218,7 +1203,7 @@ out:
  * should probably live in the boot loader.
  * The code is here mostly for educational/testing purposes.
  */
-bool
+static bool
 pcr_authorized_policy_unseal_secret(const tpm_pcr_selection_t *pcr_selection,
 				const char *signed_policy_path,
 				const stored_key_t *public_key_file,
@@ -1461,8 +1446,11 @@ cleanup:
 }
 
 /* Unseal the key in TPM 2.0 Key File format */
-bool
-pcr_policy_unseal_tpm2key(const char *input_path, const char *output_path)
+static bool
+tpm2key_unseal_secret(const char *input_path, const char *output_path,
+				const tpm_pcr_selection_t *pcr_selection,
+				const char *signed_policy_path,
+				const stored_key_t *public_key_file)
 {
 	ESYS_CONTEXT *esys_context = tss_esys_context();
 	TSSPRIVKEY *tpm2key = NULL;
@@ -1537,6 +1525,21 @@ cleanup:
 }
 
 bool
+pcr_unseal_secret_new(const target_platform_t *platform,
+				const tpm_pcr_selection_t *pcr_selection,
+				const char *signed_policy_path,
+				const stored_key_t *public_key_file,
+				const char *input_path, const char *output_path)
+{
+	if (!platform->unseal_secret) {
+		error("target platform %s does not support unsealing yet\n", platform->name);
+		return false;
+	}
+
+	return platform->unseal_secret(input_path, output_path, pcr_selection, signed_policy_path, public_key_file);
+}
+
+bool
 pcr_policy_sign_systemd(const tpm_pcr_bank_t *bank,
 			const stored_key_t *private_key_file,
 			const char *output_path)
@@ -1585,4 +1588,182 @@ out:
 
 	fclose(fp);
 	return ok;
+}
+
+/*
+ * Depending on the target platform, sealed data, authorized policies etc are
+ * written to different types of files.
+ */
+static bool
+oldgrub_write_sealed_secret(const char *pathname,
+					const TPML_PCR_SELECTION *pcr_sel,
+					const TPM2B_PRIVATE *sealed_private,
+					const TPM2B_PUBLIC *sealed_public)
+{
+	/* Just marshal public and private portions and concat them into a single file. */
+	return write_sealed_secret(pathname, sealed_public, sealed_private);
+}
+
+static bool
+oldgrub_write_signed_policy(const char *input_path, const char *output_path,
+					const char *policy_name,
+					const tpm_pcr_bank_t *bank,
+					const TPM2B_DIGEST *pcr_policy,
+					const tpm_rsa_key_t *signing_key,
+					const TPMT_SIGNATURE *signed_policy)
+{
+	/* Just write the signature, that's all */
+	return write_signature(output_path, signed_policy);
+}
+
+static bool
+oldgrub_unseal_secret(const char *input_path, const char *output_path,
+				const tpm_pcr_selection_t *pcr_selection,
+				const char *signed_policy_path,
+				const stored_key_t *public_key_file)
+{
+	if (signed_policy_path == NULL)
+		return pcr_unseal_secret_pcr(pcr_selection, input_path, output_path);
+
+	return pcr_authorized_policy_unseal_secret(pcr_selection,
+				signed_policy_path, public_key_file,
+				input_path, output_path);
+}
+
+/*
+ * This uses the TPM2.0 Key format defined in
+ * https://www.hansenpartnership.com/draft-bottomley-tpm2-keys.html
+ */
+static bool
+tpm2key_write_sealed_secret(const char *pathname,
+					const TPML_PCR_SELECTION *pcr_sel,
+					const TPM2B_PRIVATE *sealed_private,
+					const TPM2B_PUBLIC *sealed_public)
+{
+	TSSPRIVKEY *tpm2key = NULL;
+	bool ok = false;
+
+	if (!tpm2key_basekey(&tpm2key, TPM2_RH_OWNER, sealed_public, sealed_private))
+		goto cleanup;
+
+	if (pcr_sel && !tpm2key_add_policy_policypcr(tpm2key, pcr_sel))
+		goto cleanup;
+
+	ok = tpm2key_write_file(pathname, tpm2key);
+
+cleanup:
+	if (tpm2key)
+		TSSPRIVKEY_free(tpm2key);
+	return ok;
+}
+
+static bool
+tpm2key_write_signed_policy(const char *input_path, const char *output_path,
+					const char *policy_name,
+					const tpm_pcr_bank_t *bank,
+					const TPM2B_DIGEST *pcr_policy,
+					const tpm_rsa_key_t *signing_key,
+					const TPMT_SIGNATURE *signed_policy)
+{
+	TSSPRIVKEY *tpm2key = NULL;
+	TPM2B_PUBLIC *pub_key = NULL;
+	TPML_PCR_SELECTION pcr_sel;
+	bool okay = false;
+
+	if (!policy_name)
+		policy_name = "default";
+
+	/* Allow an in-place update */
+	if (input_path == NULL)
+		input_path = output_path;
+
+	if (!tpm2key_read_file(input_path, &tpm2key))
+		goto out;
+
+	if (!(pub_key = tpm_rsa_key_to_tss2(signing_key)))
+		goto out;
+
+	if (!pcr_bank_to_selection(&pcr_sel, bank))
+		goto out;
+
+	/* Prepend the signed policy */
+	if (!tpm2key_add_authpolicy_policyauthorize(tpm2key, policy_name, &pcr_sel, pub_key, signed_policy, false))
+		goto out;
+
+	okay = tpm2key_write_file(output_path, tpm2key);
+
+out:
+	if (pub_key)
+		free(pub_key);
+	if (tpm2key)
+		TSSPRIVKEY_free(tpm2key);
+
+	return okay;
+}
+
+static bool
+systemd_write_signed_policy(const char *input_path, const char *output_path,
+					const char *policy_name,
+					const tpm_pcr_bank_t *bank,
+					const TPM2B_DIGEST *pcr_policy,
+					const tpm_rsa_key_t *signing_key,
+					const TPMT_SIGNATURE *signed_policy)
+{
+	if (input_path && strcmp(input_path, output_path)) {
+		error("systemd policy will only do in-place updates of the json file\n");
+		return false;
+	}
+
+#ifdef notyet
+	sdb_policy_file_add_entry(output_path,
+			policy_name,
+			bank->algo_name,
+			bank->pcr_mask, ...);
+#endif
+	error("%s not yet implemented\n", __func__);
+	return false;
+}
+
+static target_platform_t	target_platforms[] = {
+	{
+		.name			= "oldgrub",
+		.unseal_flags		= PLATFORM_NEED_INPUT_FILE
+					| PLATFORM_NEED_OUTPUT_FILE
+					| PLATFORM_NEED_PCR_SELECTION,
+		.write_sealed_secret	= oldgrub_write_sealed_secret,
+		.write_signed_policy	= oldgrub_write_signed_policy,
+		.unseal_secret		= oldgrub_unseal_secret,
+	},
+	{
+		.name			= "tpm2.0",
+		.unseal_flags		= PLATFORM_NEED_INPUT_FILE | PLATFORM_NEED_OUTPUT_FILE,
+		.write_sealed_secret	= tpm2key_write_sealed_secret,
+		.write_signed_policy	= tpm2key_write_signed_policy,
+		.unseal_secret		= tpm2key_unseal_secret,
+	},
+	{
+		.name			= "systemd",
+		.unseal_flags		= PLATFORM_NEED_INPUT_FILE | PLATFORM_NEED_OUTPUT_FILE,
+		.write_sealed_secret	= tpm2key_write_sealed_secret,
+		.write_signed_policy	= systemd_write_signed_policy,
+	},
+	{ NULL }
+};
+
+const target_platform_t *
+pcr_get_target_platform(const char *name)
+{
+	target_platform_t *tp;
+
+	for (tp = target_platforms; tp->name; ++tp) {
+		if (!strcmp(tp->name, name))
+			return tp;
+	}
+	return NULL;
+}
+
+unsigned int
+target_platform_unseal_flags(const target_platform_t *platform)
+{
+	return platform->unseal_flags;
 }

--- a/src/pcr.h
+++ b/src/pcr.h
@@ -61,24 +61,36 @@ extern bool		pcr_authorized_policy_create(const tpm_pcr_selection_t *pcr_selecti
 				const char *output_path);
 extern bool		pcr_store_public_key(const stored_key_t *private_key_file,
 				const stored_key_t *public_key_file);
-extern bool		pcr_policy_sign(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
+extern bool		pcr_policy_sign(const target_platform_t *platform, const tpm_pcr_bank_t *bank,
 				const stored_key_t *private_key_file,
 				const char *input_path,
 				const char *output_path, const char *policy_name);
 extern bool		pcr_policy_sign_systemd(const tpm_pcr_bank_t *bank,
 				const stored_key_t *private_key_file,
 				const char *output_path);
-extern bool		pcr_authorized_policy_seal_secret(const bool tpm2key_fmt,
+extern bool		pcr_authorized_policy_seal_secret(const target_platform_t *platform,
 				const char *authorized_policy, const char *input_path,
 				const char *output_path);
-extern bool		pcr_authorized_policy_unseal_secret(const tpm_pcr_selection_t *pcr_selection,
+extern bool		pcr_seal_secret(const target_platform_t *, const tpm_pcr_bank_t *bank,
+				const char *input_path, const char *output_path);
+extern bool		pcr_unseal_secret_new(const target_platform_t *,
+				const tpm_pcr_selection_t *pcr_selection,
 				const char *signed_policy_path,
 				const stored_key_t *public_key_file,
 				const char *input_path, const char *output_path);
-extern bool		pcr_seal_secret(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
-				const char *input_path, const char *output_path);
-extern bool		pcr_unseal_secret(const tpm_pcr_selection_t *pcr_selection,
-				const char *input_path, const char *output_path);
 extern bool		pcr_policy_unseal_tpm2key(const char *input_path,
 				const char *output_path);
+
+extern const target_platform_t *pcr_get_target_platform(const char *name);
+
+/* Flags that indicate the set of arguments required for a specific operation */
+#define PLATFORM_NEED_INPUT_FILE	0x0001
+#define PLATFORM_NEED_OUTPUT_FILE	0x0002
+#define PLATFORM_NEED_PCR_SELECTION	0x0004
+#define PLATFORM_NEED_PUBLIC_KEY	0x0008
+#define PLATFORM_NEED_SIGNED_POLICY	0x0010
+#define PLATFORM_OPTIONAL_PCR_POLICY	0x0020
+
+extern unsigned int	target_platform_unseal_flags(const target_platform_t *);
+
 #endif /* PCR_H */

--- a/src/pcr.h
+++ b/src/pcr.h
@@ -57,19 +57,23 @@ extern void		pcr_selection_free(tpm_pcr_selection_t *);
 
 extern bool		pcr_read_into_bank(tpm_pcr_bank_t *bank);
 extern bool		pcr_authorized_policy_create(const tpm_pcr_selection_t *pcr_selection,
-				const char *rsakey_path, const char *output_path);
-extern bool		pcr_store_public_key(const char *rsakey_path, const char *output_path);
+				const stored_key_t *private_key_file,
+				const char *output_path);
+extern bool		pcr_store_public_key(const stored_key_t *private_key_file,
+				const stored_key_t *public_key_file);
 extern bool		pcr_policy_sign(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
-				const char *rsakey_path, const char *input_path,
+				const stored_key_t *private_key_file,
+				const char *input_path,
 				const char *output_path, const char *policy_name);
-extern bool		pcr_policy_sign_systemd(const tpm_pcr_bank_t *bank, const char *rsakey_path,
+extern bool		pcr_policy_sign_systemd(const tpm_pcr_bank_t *bank,
+				const stored_key_t *private_key_file,
 				const char *output_path);
 extern bool		pcr_authorized_policy_seal_secret(const bool tpm2key_fmt,
 				const char *authorized_policy, const char *input_path,
 				const char *output_path);
 extern bool		pcr_authorized_policy_unseal_secret(const tpm_pcr_selection_t *pcr_selection,
 				const char *signed_policy_path,
-				const char *rsakey_path,
+				const stored_key_t *public_key_file,
 				const char *input_path, const char *output_path);
 extern bool		pcr_seal_secret(const bool tpm2key_fmt, const tpm_pcr_bank_t *bank,
 				const char *input_path, const char *output_path);

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -355,9 +355,9 @@ tpm_rsa_key_to_tss2(const tpm_rsa_key_t *key)
 	return rsa_pubkey_alloc(n, e, key->path);
 }
 
-/* FIXME argument should be const */
 const tpm_evdigest_t *
-tpm_rsa_key_public_digest(tpm_rsa_key_t *pubkey) {
+tpm_rsa_key_public_digest(const tpm_rsa_key_t *pubkey)
+{
 	unsigned int der_size;
 	unsigned char *der, *bder = NULL;
 	const tpm_algo_info_t *algo;

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -355,6 +355,7 @@ tpm_rsa_key_to_tss2(const tpm_rsa_key_t *key)
 	return rsa_pubkey_alloc(n, e, key->path);
 }
 
+/* FIXME argument should be const */
 const tpm_evdigest_t *
 tpm_rsa_key_public_digest(tpm_rsa_key_t *pubkey) {
 	unsigned int der_size;

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -57,7 +57,11 @@ tpm_rsa_key_alloc(const char *path, EVP_PKEY *pkey, bool priv)
 void
 tpm_rsa_key_free(tpm_rsa_key_t *key)
 {
-	/* TBD */
+	drop_string(&key->path);
+	if (key->pkey) {
+		EVP_PKEY_free(key->pkey);
+		key->pkey = NULL;
+	}
 }
 
 /*

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -134,6 +134,32 @@ fail:
 }
 
 /*
+ * Write a public key to a PEM file.
+ */
+bool
+tpm_rsa_key_write_public(const char *pathname, const tpm_rsa_key_t *key)
+{
+	bool ok = false;
+	FILE *fp;
+
+	if (!(fp = fopen(pathname, "w"))) {
+		error("Cannot open RSA public key file %s: %m\n", pathname);
+		goto fail;
+	}
+
+	if (!PEM_write_PUBKEY(fp, key->pkey)) {
+		error("Unable to write public key to %s\n", pathname);
+		goto fail;
+	}
+
+	ok = true;
+
+fail:
+	fclose(fp);
+	return ok;
+}
+
+/*
  * Read a private key from a PEM file.
  * Pass phrases currently not supported.
  */

--- a/src/rsa.h
+++ b/src/rsa.h
@@ -27,6 +27,8 @@ typedef struct tpm_rsa_key	tpm_rsa_key_t;
 
 extern tpm_rsa_key_t *	tpm_rsa_key_read_public(const char *pathname);
 extern tpm_rsa_key_t *	tpm_rsa_key_read_private(const char *pathname);
+extern bool		tpm_rsa_key_write_public(const char *pathname,
+				const tpm_rsa_key_t *key);
 extern bool		tpm_rsa_key_write_private(const char *pathname,
 				const tpm_rsa_key_t *key);
 extern void		tpm_rsa_key_free(tpm_rsa_key_t *key);

--- a/src/rsa.h
+++ b/src/rsa.h
@@ -22,6 +22,7 @@
 #define RSA_H
 
 #include <tss2_tpm2_types.h>
+#include "types.h"
 
 typedef struct tpm_rsa_key	tpm_rsa_key_t;
 
@@ -40,4 +41,5 @@ extern int		tpm_rsa_sign(const tpm_rsa_key_t *,
 extern TPM2B_PUBLIC *	tpm_rsa_key_to_tss2(const tpm_rsa_key_t *key);
 
 extern const tpm_evdigest_t * tpm_rsa_key_public_digest(tpm_rsa_key_t *pubkey);
+
 #endif /* RSA_H */

--- a/src/rsa.h
+++ b/src/rsa.h
@@ -40,6 +40,6 @@ extern int		tpm_rsa_sign(const tpm_rsa_key_t *,
 
 extern TPM2B_PUBLIC *	tpm_rsa_key_to_tss2(const tpm_rsa_key_t *key);
 
-extern const tpm_evdigest_t * tpm_rsa_key_public_digest(tpm_rsa_key_t *pubkey);
+extern const tpm_evdigest_t * tpm_rsa_key_public_digest(const tpm_rsa_key_t *pubkey);
 
 #endif /* RSA_H */

--- a/src/sd-boot.c
+++ b/src/sd-boot.c
@@ -541,7 +541,7 @@ sdb_policy_file_add_entry(const char *filename, const char *policy_name, const c
 	json_object_object_add(entry, "sig",
 			json_object_new_string(print_base64_value(signature, signature_len)));
 
-	if (json_object_to_file(filename, doc)) {
+	if (json_object_to_file_ext(filename, doc, JSON_C_TO_STRING_PRETTY)) {
 		error("%s: unable to write json file: %s\n", filename, json_util_get_last_err());
 		goto out;
 	}

--- a/src/sd-boot.h
+++ b/src/sd-boot.h
@@ -45,7 +45,7 @@ extern bool			sdb_is_kernel(const char *application);
 extern const char *		sdb_get_next_kernel(void);
 
 /* This will have to update the systemd json file, and add a new entry. */
-extern void			sdb_policy_file_add_entry(const char *filename,
+extern bool			sdb_policy_file_add_entry(const char *filename,
 						const char *policy_name,
 						const char *algo_name,
 						unsigned int pcr_mask,

--- a/src/sd-boot.h
+++ b/src/sd-boot.h
@@ -44,4 +44,13 @@ extern bool			sdb_get_entry_list(sdb_entry_list_t *result);
 extern bool			sdb_is_kernel(const char *application);
 extern const char *		sdb_get_next_kernel(void);
 
+/* This will have to update the systemd json file, and add a new entry. */
+extern void			sdb_policy_file_add_entry(const char *filename,
+						const char *policy_name,
+						const char *algo_name,
+						unsigned int pcr_mask,
+						const void *fingerprint, unsigned int fingerprint_len,
+						const void *policy, unsigned int policy_len,
+						const void *signature, unsigned int signature_len);
+
 #endif /* SD_BOOT_H */

--- a/src/store.c
+++ b/src/store.c
@@ -1,0 +1,245 @@
+/*
+ *   Copyright (C) 2023 SUSE LLC
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * Written by Olaf Kirch <okir@suse.com>
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "store.h"
+#include "util.h"
+#include "tpm.h"
+
+/* We do not have automatic conversion of TPM2B_PUBLIC to RSA yet (and so far we haven't needed it) */
+#undef WITH_NATIVE_TO_RSA_CONVERSTION
+
+tpm_rsa_key_t *
+stored_key_read_rsa_private(const stored_key_t *sk)
+{
+	switch (sk->format) {
+	case STORED_KEY_FMT_PEM:
+		return tpm_rsa_key_read_private(sk->path);
+	}
+
+	error("Unable to read RSA private key from file \"%s\": unsupported format\n", sk->path);
+	return NULL;
+}
+
+bool
+stored_key_write_rsa_private(const stored_key_t *sk, const tpm_rsa_key_t *key)
+{
+	if (!sk->is_private) {
+		error("Refusing to write RSA private key to file \"%s\": file is supposed to contain public key\n", sk->path);
+		return false;
+	}
+
+	switch (sk->format) {
+	case STORED_KEY_FMT_PEM:
+		return tpm_rsa_key_write_private(sk->path, key);
+	}
+
+	error("Unable to write RSA private key to file \"%s\": unsupported format\n", sk->path);
+	return false;
+}
+
+tpm_rsa_key_t *
+stored_key_read_rsa_public(const stored_key_t *sk)
+{
+	debug2("Trying to read RSA public key from %s file %s\n",
+			sk->is_private? "private" : "public",
+			sk->path);
+
+	/* If the stored object is actually a private key, just read it and go with it. */
+	if (sk->is_private)
+		return stored_key_read_rsa_private(sk);
+
+	switch (sk->format) {
+	case STORED_KEY_FMT_PEM:
+		return tpm_rsa_key_read_public(sk->path);
+
+	case STORED_KEY_FMT_NATIVE:
+		error("Unable to read RSA public key from native file \"%s\": automatic conversion not implemented\n", sk->path);
+		return NULL;
+	}
+
+	error("Unable to read RSA public key from file \"%s\": unsupported format\n", sk->path);
+	return NULL;
+}
+
+bool
+stored_key_write_rsa_public(const stored_key_t *sk, const tpm_rsa_key_t *key)
+{
+	switch (sk->format) {
+	case STORED_KEY_FMT_PEM:
+		return tpm_rsa_key_write_public(sk->path, key);
+
+	/* If the format is native, automatically convert the RSA key to a native TPM2B_PUBLIC blob */
+	case STORED_KEY_FMT_NATIVE:
+		{
+			TPM2B_PUBLIC *native_key;
+			bool ok;
+
+			native_key = tpm_rsa_key_to_tss2(key);
+			if (native_key == NULL) {
+				error("Error writing RSA public key to native file %s: failed to convert key\n", sk->path);
+				return false;
+			}
+
+			ok = tss_write_public_key(sk->path, native_key);
+			free(native_key);
+			return ok;
+		}
+	}
+
+	error("Unable to write RSA public key to file \"%s\": unsupported format\n", sk->path);
+	return false;
+}
+
+TPM2B_PUBLIC *
+stored_key_read_native_public(const stored_key_t *sk)
+{
+	debug2("Trying to read TPM formatted public key from %s file %s\n",
+			sk->is_private? "private" : "public",
+			sk->path);
+
+	switch (sk->format) {
+	case STORED_KEY_FMT_NATIVE:
+		return tss_read_public_key(sk->path);
+
+	case STORED_KEY_FMT_PEM:
+		{
+			tpm_rsa_key_t *rsa_key;
+			TPM2B_PUBLIC *native_key;
+
+			rsa_key = stored_key_read_rsa_public(sk);
+			if (rsa_key == NULL)
+				return NULL;
+
+			native_key = tpm_rsa_key_to_tss2(rsa_key);
+			tpm_rsa_key_free(rsa_key);
+
+			if (native_key == NULL) {
+				error("Error reading TPM public key from native file %s: failed to convert key\n", sk->path);
+				return NULL;
+			}
+
+			return native_key;
+		}
+	}
+
+	error("Unable to read native TPM public key from file \"%s\": unsupported format\n", sk->path);
+	return NULL;
+}
+
+bool
+stored_key_write_native_public(const stored_key_t *sk, const TPM2B_PUBLIC *native_key)
+{
+	switch (sk->format) {
+	case STORED_KEY_FMT_NATIVE:
+		return tss_write_public_key(sk->path, native_key);
+
+	case STORED_KEY_FMT_PEM:
+		error("Unable to write native public key to PEM file \"%s\": automatic conversion not implemented\n", sk->path);
+		return false;
+	}
+
+	error("Unable to write native TPM public key to file \"%s\": unsupported format\n", sk->path);
+	return NULL;
+}
+
+static const char *
+stored_key_format_to_name(int fmt)
+{
+	switch (fmt) {
+	case STORED_KEY_FMT_PEM:
+		return "PEM";
+	case STORED_KEY_FMT_NATIVE:
+		return "native";
+	}
+
+	return "<unknown>";
+}
+
+void
+stored_key_set_format(stored_key_t *sk, int objfmt)
+{
+	if (sk->format && sk->format != objfmt)
+		fatal("Ambiguous key format for %s: %s vs %s\n", sk->path,
+				stored_key_format_to_name(sk->format),
+				stored_key_format_to_name(objfmt));
+	sk->format = objfmt;
+}
+
+void
+stored_key_set_path(stored_key_t *sk, const char *pathname)
+{
+	assign_string(&sk->path, pathname);
+
+	if (pathname == NULL)
+		fatal("%s: pathname is NULL\n", __func__);
+
+	if (!strncasecmp(pathname, "pem:", 4)) {
+		stored_key_set_format(sk, STORED_KEY_FMT_PEM);
+		pathname += 4;
+	} else
+	if (!strncasecmp(pathname, "native:", 7)) {
+		stored_key_set_format(sk, STORED_KEY_FMT_NATIVE);
+		pathname += 7;
+	} else
+	if (path_has_file_extension(pathname, "pem"))
+		stored_key_set_format(sk, STORED_KEY_FMT_PEM);
+}
+
+/*
+ * Constructors
+ */
+static inline stored_key_t *
+__stored_key_new(bool is_private, int objfmt, const char *pathname)
+{
+	stored_key_t *sk;
+
+	sk = calloc(1, sizeof(*sk));
+	sk->is_private = is_private;
+	stored_key_set_path(sk, pathname);
+
+	if (sk->format == 0)
+		stored_key_set_format(sk, objfmt);
+
+	return sk;
+}
+
+stored_key_t *
+stored_key_new_public(int objfmt, const char *pathname)
+{
+	return __stored_key_new(false, objfmt, pathname);
+}
+
+stored_key_t *
+stored_key_new_private(int objfmt, const char *pathname)
+{
+	return __stored_key_new(true, objfmt, pathname);
+}
+
+/*
+ * Destructor
+ */
+void
+stored_key_free(stored_key_t *sk)
+{
+	drop_string(&sk->path);
+	free(sk);
+}

--- a/src/store.h
+++ b/src/store.h
@@ -1,0 +1,55 @@
+/*
+ *   Copyright (C) 2023 SUSE LLC
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * Written by Olaf Kirch <okir@suse.com>
+ */
+
+#ifndef STORE_H
+#define STORE_H
+
+#include <stdbool.h>
+#include <tss2_esys.h>
+
+#include "types.h"
+#include "rsa.h"
+
+enum {
+	STORED_KEY_FMT_PEM		= 1,
+	STORED_KEY_FMT_NATIVE	= 2,	/* TSS marshaled */
+};
+
+struct stored_key {
+	char *		path;
+	bool		is_private;
+	int		format;
+};
+
+extern stored_key_t *	stored_key_new_public(int objfmt, const char *pathname);
+extern stored_key_t *	stored_key_new_private(int objfmt, const char *pathname);
+extern void		stored_key_free(stored_key_t *);
+extern tpm_rsa_key_t *	stored_key_read_rsa_public(const stored_key_t *);
+extern bool		stored_key_write_rsa_public(const stored_key_t *, const tpm_rsa_key_t *key);
+extern tpm_rsa_key_t *	stored_key_read_rsa_private(const stored_key_t *);
+extern bool		stored_key_write_rsa_private(const stored_key_t *, const tpm_rsa_key_t *key);
+extern TPM2B_PUBLIC *	stored_key_read_native_public(const stored_key_t *);
+extern bool		stored_key_write_native_public(const stored_key_t *, const TPM2B_PUBLIC *);
+
+extern TPM2B_PUBLIC *	stored_key_read_native_public(const stored_key_t *);
+extern bool		stored_key_write_native_public(const stored_key_t *, const TPM2B_PUBLIC *key);
+
+#endif /* STORE_H */
+

--- a/src/tpm.h
+++ b/src/tpm.h
@@ -31,6 +31,9 @@ extern uint32_t		esys_tr_rh_owner;
 extern ESYS_CONTEXT *	tss_esys_context(void);
 extern void		tss_print_error(int rc, const char *msg);
 
+extern TPM2B_PUBLIC *	tss_read_public_key(const char *);
+extern bool		tss_write_public_key(const char *, const TPM2B_PUBLIC *);
+
 static inline bool
 tss_check_error(int rc, const char *msg)
 {

--- a/src/types.h
+++ b/src/types.h
@@ -34,6 +34,7 @@ typedef struct parsed_cert	parsed_cert_t;
 typedef struct pecoff_image_info pecoff_image_info_t;
 typedef struct testcase		testcase_t;
 typedef struct stored_key	stored_key_t;
+typedef struct target_platform	target_platform_t;
 
 #endif /* TYPES_H */
 

--- a/src/types.h
+++ b/src/types.h
@@ -33,6 +33,7 @@ typedef struct cert_table	cert_table_t;
 typedef struct parsed_cert	parsed_cert_t;
 typedef struct pecoff_image_info pecoff_image_info_t;
 typedef struct testcase		testcase_t;
+typedef struct stored_key	stored_key_t;
 
 #endif /* TYPES_H */
 

--- a/src/util.c
+++ b/src/util.c
@@ -190,24 +190,31 @@ print_octet_string(const unsigned char *data, unsigned int len)
 }
 
 const char *
+print_hex_string_buffer(const unsigned char *data, unsigned int len, char *buffer, size_t size)
+{
+	const char *orig_buffer = buffer;
+	unsigned int i;
+
+	if (size < 2 * len + 1)
+		fatal("%s: output buffer too small\n", __func__);
+
+	for (i = 0; i < len; ++i) {
+		sprintf(buffer, "%02x", data[i]);
+		buffer += 2;
+	}
+	*buffer = '\0';
+	return orig_buffer;
+}
+
+const char *
 print_hex_string(const unsigned char *data, unsigned int len)
 {
 	static char buffer[2 * 64 + 1];
 
-	if (len <= 64) {
-		unsigned int i;
-		char *s;
+	if (len <= 64)
+		return print_hex_string_buffer(data, len, buffer, sizeof(buffer));
 
-		s = buffer;
-		for (i = 0; i < len; ++i) {
-			sprintf(s, "%02x", data[i]);
-			s += 2;
-		}
-		*s = '\0';
-	} else {
-		snprintf(buffer, sizeof(buffer), "<%u bytes of data>", len);
-	}
-
+	snprintf(buffer, sizeof(buffer), "<%u bytes of data>", len);
 	return buffer;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -472,3 +472,17 @@ path_unix2dos(const char *path)
 
 	return result;
 }
+
+bool
+path_has_file_extension(const char *path, const char *suffix)
+{
+	const char *s;
+
+	if (!(s = strrchr(path, '.')))
+		return false;
+
+	if (*suffix == '.')
+		++suffix;
+
+	return !strcasecmp(s + 1, suffix);
+}

--- a/src/util.h
+++ b/src/util.h
@@ -138,6 +138,7 @@ extern double		timing_begin(void);
 extern double		timing_since(double);
 
 extern const char *	path_unix2dos(const char *path);
+extern bool		path_has_file_extension(const char *path, const char *suffix);
 
 extern int		version_string_compare(const char *, const char *);
 

--- a/src/util.h
+++ b/src/util.h
@@ -129,6 +129,8 @@ extern const tpm_evdigest_t *parse_digest(const char *string, const char *algo);
 extern void		hexdump(const void *data, size_t size, void (*)(const char *, ...), unsigned int indent);
 extern const char *	print_octet_string(const unsigned char *data, unsigned int len);
 extern const char *	print_hex_string(const unsigned char *data, unsigned int len);
+extern const char *	print_hex_string_buffer(const unsigned char *data, unsigned int len,
+				char *buffer, size_t size);
 extern const char *	print_base64_value(const unsigned char *data, unsigned int len);
 
 extern bool		__convert_from_utf16le(char *in_string, size_t in_bytes, char *out_string, size_t out_bytes);

--- a/test-authorized.sh
+++ b/test-authorized.sh
@@ -43,6 +43,25 @@ call_oracle \
 	--public-key policy-pubkey \
 	store-public-key
 
+# Write the same public key, but as PEM file.
+call_oracle \
+	--private-key policy-key.pem \
+	--public-key policy-pubkey.pem \
+	store-public-key
+
+# Make sure that the PEM formatted public key we extracted matches what openssl would produce
+openssl rsa -inform PEM -in policy-key.pem -outform PEM -out pubkey2.pem -pubout
+if ! cmp pubkey2.pem policy-pubkey.pem; then
+	echo "BAD: storing the public key did not generate the same PEM file as openssl did"
+	for fname in policy-pubkey.pem pubkey2.pem; do
+		echo "$fname"
+		cat $fname
+		echo
+	done
+	exit 1
+fi
+rm -f pubkey2.pem
+
 call_oracle \
 	--auth authorized.policy \
 	--input secret \

--- a/test-pcr.sh
+++ b/test-pcr.sh
@@ -59,11 +59,8 @@ echo "Extend PCR 12. Unsealing should fail afterwards"
 tpm2_pcrextend 12:sha256=21d2013e3081f1e455fdd5ba6230a8620c3cfc9a9c31981d857fe3891f79449e
 rm -f recovered
 call_oracle \
-	--auth authorized.policy \
 	--input sealed \
 	--output recovered \
-	--public-key policy-pubkey \
-	--pcr-policy signed.policy \
 	unseal-secret $PCR_MASK || true
 
 if [ -s recovered ] && ! cmp secret recovered; then


### PR DESCRIPTION
 Replace --key-format and --policy-format options with a single --target-platform option
    
    Introduce a struct target_platform to abstract away the specifics of file formats
    and behavior of different target platforms.
    
    Currently supported target platforms:
     - oldgrub
     - tpm2.0
     - systemd (not fully implemented)
