### PR TITLE
[RFC] Compare the current TPM events with the predicted events

### DIFF
--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -449,6 +449,34 @@ __tpm_event_print(tpm_event_t *ev, tpm_event_bit_printer *print_fn)
 	hexdump(ev->event_data, ev->event_size, print_fn, 8);
 }
 
+void
+tpm_predicted_event_print(tpm_event_t *ev)
+{
+	__tpm_predicted_event_print(ev, (void (*)(const char *, ...)) printf);
+}
+
+void
+__tpm_predicted_event_print(tpm_event_t *ev, tpm_event_bit_printer *print_fn)
+{
+	print_fn("%05lx: event type=%s pcr=%d data=%u bytes\n",
+			ev->file_offset,
+			tpm_event_type_to_string(ev->event_type),
+			ev->pcr_index, ev->event_size);
+
+	if (ev->__parsed)
+		tpm_parsed_event_print(ev->__parsed, print_fn);
+
+	if (!ev->predicted_digest.algo) {
+		print_fn("  %-10s\n", "no predicted digest");
+	} else {
+		const tpm_evdigest_t *d = &ev->predicted_digest;
+		print_fn("  %-10s %s\n", d->algo->openssl_name, digest_print_value(d));
+	}
+
+	print_fn("  Data:\n");
+	hexdump(ev->event_data, ev->event_size, print_fn, 8);
+}
+
 static const tpm_evdigest_t *
 __tpm_event_rehash_efi_variable(const char *var_name, tpm_event_log_rehash_ctx_t *ctx)
 {

--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -21,6 +21,7 @@
 #ifndef EVENTLOG_H
 #define EVENTLOG_H
 
+#include "digest.h"
 #include "types.h"
 
 typedef struct tpm_event {
@@ -42,6 +43,8 @@ typedef struct tpm_event {
 
 	/* set by the predictor during pre-scan */
 	int			rehash_strategy;
+
+	tpm_evdigest_t		predicted_digest;
 } tpm_event_t;
 
 typedef void			tpm_event_bit_printer(const char *, ...);
@@ -287,6 +290,8 @@ extern unsigned int		event_log_get_event_count(const tpm_event_log_reader_t *log
 extern unsigned int		event_log_get_tpm_version(const tpm_event_log_reader_t *log);
 extern void			tpm_event_print(tpm_event_t *ev);
 extern void			__tpm_event_print(tpm_event_t *ev, tpm_event_bit_printer *print_fn);
+extern void			tpm_predicted_event_print(tpm_event_t *ev);
+extern void			__tpm_predicted_event_print(tpm_event_t *ev, tpm_event_bit_printer *print_fn);
 extern void			tpm_event_log_rehash_ctx_init(tpm_event_log_rehash_ctx_t *,
 					const tpm_algo_info_t *);
 extern void			tpm_event_log_rehash_ctx_destroy(tpm_event_log_rehash_ctx_t *);

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -101,6 +101,7 @@ enum {
 	OPT_POLICY_FORMAT,
 	OPT_TARGET_PLATFORM,
 	OPT_BOOT_ENTRY,
+	OPT_COMPARE_CURRENT,
 };
 
 static struct option options[] = {
@@ -134,6 +135,7 @@ static struct option options[] = {
 	{ "policy-format",	required_argument,	0,	OPT_POLICY_FORMAT },
 	{ "target-platform",	required_argument,	0,	OPT_TARGET_PLATFORM },
 	{ "next-kernel",	required_argument,	0,	OPT_BOOT_ENTRY },
+	{ "compare-current",	no_argument,		0,	OPT_COMPARE_CURRENT },
 
 	{ NULL }
 };
@@ -758,6 +760,8 @@ predictor_update_eventlog(struct predictor *pred)
 			}
 
 			predictor_extend_hash(pred, ev->pcr_index, new_digest);
+
+			memcpy(&ev->predicted_digest, new_digest, sizeof(tpm_evdigest_t));
 		}
 
 no_action:
@@ -884,6 +888,87 @@ predictor_verify(struct predictor *pred, const char *source)
 	if (num_mismatches)
 		error("Found %u mismatches\n", num_mismatches);
 	return num_mismatches;
+}
+
+static bool
+compare_events(struct predictor *pred, struct predictor *pred_cmp,
+	       unsigned int pcr_index, tpm_event_t *stop_event)
+{
+	tpm_event_t *ev, *ev_cmp;
+	const tpm_evdigest_t *predicted_digest, *cmp_digest;
+
+	for(ev = pred->event_log, ev_cmp = pred_cmp->event_log; ev; ev = ev->next, ev_cmp = ev_cmp->next) {
+		bool stop = false;
+		stop = (ev == stop_event);
+		if (stop && !pred->stop_event.after) {
+			debug("Stopped processing event log before indicated event\n");
+			break;
+		}
+
+		if (ev->pcr_index == pcr_index) {
+			/* Advance the event in the comparison event log */
+			while(ev_cmp) {
+				if (ev_cmp->pcr_index == pcr_index)
+					break;
+				ev_cmp = ev_cmp->next;
+			}
+
+			if (ev_cmp == NULL) {
+				tpm_event_print(ev);
+				printf("No corresponding event in the comparison event log\n");
+				printf("\n");
+				return false;
+			}
+
+			if (!(cmp_digest = tpm_event_get_digest(ev_cmp, pred->algo_info)))
+				fatal("Comparison event log lacks a hash for digest algorithm %s\n", pred->algo);
+			if (ev->predicted_digest.algo) {
+				predicted_digest = &ev->predicted_digest;
+
+				if (predicted_digest->size == cmp_digest->size
+				    && memcmp(predicted_digest->data, cmp_digest->data, cmp_digest->size)) {
+					printf("Predicted event:\n");
+					tpm_predicted_event_print(ev);
+					printf("Actual event:\n");
+					tpm_event_print(ev_cmp);
+					printf("\n");
+
+					return false;
+				}
+			}
+		}
+
+		if (stop) {
+			debug("Stopped processing event log after indicated event\n");
+			break;
+		}
+	}
+
+	return true;
+}
+
+static unsigned int
+predictor_compare(struct predictor *pred, struct predictor *pred_cmp)
+{
+	const tpm_pcr_bank_t *bank = &pred->prediction;
+	unsigned int pcr_index;
+	tpm_event_t *stop_event = NULL;
+	unsigned int num_diff = 0;
+
+	predictor_pre_scan_eventlog(pred, &stop_event);
+
+	for (pcr_index = 0; pcr_index < PCR_BANK_REGISTER_MAX; ++pcr_index) {
+		if (!pcr_bank_register_is_valid(bank, pcr_index))
+			continue;
+
+		if (!compare_events(pred, pred_cmp, pcr_index, stop_event))
+			num_diff++;
+	}
+
+	if (num_diff == 0)
+		printf("Predicted event log matches.\n");
+
+	return 0;
 }
 
 static void
@@ -1015,6 +1100,7 @@ int
 main(int argc, char **argv)
 {
 	struct predictor *pred;
+	struct predictor *pred_cmp;
 	int action = ACTION_NONE;
 	tpm_pcr_selection_t *pcr_selection = NULL;
 	char *opt_from = NULL;
@@ -1037,6 +1123,7 @@ main(int argc, char **argv)
 	char *opt_policy_name = NULL;
 	char *opt_target_platform = NULL;
 	char *opt_boot_entry = NULL;
+	bool opt_compare_current = false;
 	const target_platform_t *target;
 	unsigned int action_flags = 0;
 	unsigned int rsa_bits = 2048;
@@ -1135,6 +1222,9 @@ main(int argc, char **argv)
 		case OPT_TARGET_PLATFORM:
 			opt_target_platform = optarg;
 			break;
+		case OPT_COMPARE_CURRENT:
+			opt_compare_current = true;
+			break;
 		case 'h':
 			usage(0, NULL);
 		default:
@@ -1152,6 +1242,9 @@ main(int argc, char **argv)
 
 	if (opt_create_testcase)
 		runtime_record_testcase(testcase_alloc(opt_create_testcase));
+
+	if (!opt_replay_testcase && opt_compare_current)
+		fatal("--compare-current is only valid for --replay-testcase\n");
 
 	if (opt_rsa_bits) {
 		if (strcmp(opt_rsa_bits, "2048") == 0)
@@ -1320,12 +1413,24 @@ main(int argc, char **argv)
 	if (opt_stop_event)
 		predictor_set_stop_event(pred, opt_stop_event, !opt_stop_before);
 
+	if (opt_compare_current) {
+		testcase_t *tc_playback = runtime_get_replay_testcase();
+		/* Disable replay testcase temporarily to access the current TPM event log*/
+		runtime_replay_testcase(NULL);
+		pred_cmp = predictor_new(pcr_selection, "eventlog", NULL,
+					 opt_output_format, opt_boot_entry);
+		/* Restore replay testcase */
+		runtime_replay_testcase(tc_playback);
+	}
+
 	if (!predictor_update_all(pred, argc - optind, argv + optind))
 		return 1;
 
 	if (action == ACTION_PREDICT) {
 		if (opt_verify)
 			exit_code = !!predictor_verify(pred, opt_verify);
+		else if (opt_compare_current)
+			exit_code = !!predictor_compare(pred, pred_cmp);
 		else
 			predictor_report(pred);
 	} else

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -70,6 +70,12 @@ runtime_replay_testcase(testcase_t *tc)
 	testcase_playback = tc;
 }
 
+testcase_t *
+runtime_get_replay_testcase(void)
+{
+	return testcase_playback;
+}
+
 file_locator_t *
 runtime_locate_file(const char *device_path, const char *file_path)
 {

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -50,6 +50,7 @@ extern unsigned int	runtime_blockdev_bytes_to_sectors(const block_dev_io_t *, un
 
 extern void		runtime_record_testcase(testcase_t *);
 extern void		runtime_replay_testcase(testcase_t *);
+extern testcase_t *	runtime_get_replay_testcase(void);
 
 #include <stdio.h>
 


### PR DESCRIPTION
When investigating the TPM unsealing failure, it'd be easier to identify the issue by comparing the predicted event log and the current event log. With '--create-testcase', the system status is snapshotted and '--replay-testcase' can reconstruct the events to be predicted.

This commit adds a new option, --compare-current, to compare the current TPM event log with the predicted events. It goes through the specified PCR indices in both current event log and the predicted events to identify the first different event.

The sample output:

    # ./pcr-oracle --from eventlog --replay-testcase pcr-oracle.test \
    		--compare-current --stop-event "grub-file=grub.cfg" --after \
    		predict 0,2,4,7,9
    Predicted event:
    04168: event type=EFI_BOOT_SERVICES_APPLICATION pcr=4 digests=4 data=86 bytes
    Boot Service Application; device path:
      file-path  "/EFI/opensuse/grub.efi"
      end
      sha256     086787b1bc5731794be3a117e568ddae4e6c7a587628daf406a00c8d540f5a3f
      Data:
            0000  18 a0 8e 7d 00 00 00 00 50 56 1f 00 00 00 00 00 00 00 00 00 00 00 00 00 36 00 00 00 00 00 00 00 ...}....PV..............6.......
            0020  04 04 32 00 5c 00 45 00 46 00 49 00 5c 00 6f 00 70 00 65 00 6e 00 73 00 75 00 73 00 65 00 5c 00 ..2.\.E.F.I.\.o.p.e.n.s.u.s.e.\.
            0040  67 00 72 00 75 00 62 00 2e 00 65 00 66 00 69 00 00 00 7f ff 04 00                               g.r.u.b...e.f.i.......
    Actual event:
    0486c: event type=EFI_BOOT_SERVICES_APPLICATION pcr=4 digests=4 data=86 bytes
      sha1       7251f041609f1b1b2e25236be94e4cfde2f16cd9
      sha256     a7e3ac45de9877c56ec30b3fa07a76bddb31905aff3f19af6bafbd196079f08c
      sha384     1f6ffd64830fe9eccaf86ce8211f1f88c8aa3814283eb50ceaf11d50e593b0558fde036c5fd3065e9e91f7a770af8550
      sha512     82579ebe47a13da1f054551889402a1b3cca426e980e270a8a6c5e406f093767408baa4d3dadb85bf825d81cb6581ba5309a363636d16b768fd5d4d445752d36
      Data:
            0000  18 a0 8d 7d 00 00 00 00 70 57 1f 00 00 00 00 00 00 00 00 00 00 00 00 00 36 00 00 00 00 00 00 00 ...}....pW..............6.......
            0020  04 04 32 00 5c 00 45 00 46 00 49 00 5c 00 6f 00 70 00 65 00 6e 00 73 00 75 00 73 00 65 00 5c 00 ..2.\.E.F.I.\.o.p.e.n.s.u.s.e.\.
            0040  67 00 72 00 75 00 62 00 2e 00 65 00 66 00 69 00 00 00 7f ff 04 00                               g.r.u.b...e.f.i.......
    
    Predicted event:
    002ab: event type=EFI_VARIABLE_DRIVER_CONFIG pcr=7 digests=4 data=53 bytes
      --> EFI variable SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c: 1 bytes of data
      sha256     115aa827dbccfb44d216ad9ecfda56bdea620b860a94bed5b7a27bba1c4d02d8
      Data:
            0000  61 df e4 8b ca 93 d2 11 aa 0d 00 e0 98 03 2b 8c 0a 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 a.............+.................
            0020  53 00 65 00 63 00 75 00 72 00 65 00 42 00 6f 00 6f 00 74 00 00                                  S.e.c.u.r.e.B.o.o.t..
    Actual event:
    002ab: event type=EFI_VARIABLE_DRIVER_CONFIG pcr=7 digests=4 data=53 bytes
      sha1       d4fdd1f14d4041494deb8fc990c45343d2277d08
      sha256     ccfc4bb32888a345bc8aeadaba552b627d99348c767681ab3141f5b01e40a40e
      sha384     2cded0c6f453d4c6f59c5e14ec61abc6b018314540a2367cba326a52aa2b315ccc08ce68a816ce09c6ef2ac7e514ae1f
      sha512     94a377e9002be6e1d8399bf7674d9eb4e931df34f48709fddd5e1493bfb96c19ee695387109a5a5b42f4871cbee8e32a9f3282636e99a8890762ee45bd7b34b7
      Data:
            0000  61 df e4 8b ca 93 d2 11 aa 0d 00 e0 98 03 2b 8c 0a 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 a.............+.................
            0020  53 00 65 00 63 00 75 00 72 00 65 00 42 00 6f 00 6f 00 74 00 01                                  S.e.c.u.r.e.B.o.o.t..

By comparing the predicted events and the actual events, it shows that there are unexpected events in PCR 4 and PCR 7. Both the predicted and actual PCR 4 events pointer to the same EFI application, grub.efi, but with different digests, so the change of grub.efi is detected. As for PCR 7 events, the difference in the 'Data' section indicates that the Secure Boot was enabled later.