### PR TITLE
Fix the measure of EFI images

### DIFF
--- a/configure
+++ b/configure
@@ -12,7 +12,7 @@
 # Invoke with --help for a description of options
 #
 # microconf:begin
-# version 0.5.4
+# version 0.5.5
 # require libtss2
 # require json
 # disable debug-authenticode

--- a/microconf/version
+++ b/microconf/version
@@ -1,1 +1,1 @@
-uc_version=0.5.4
+uc_version=0.5.5

--- a/src/efi-application.c
+++ b/src/efi-application.c
@@ -40,7 +40,7 @@
  */
 static const tpm_evdigest_t *	__tpm_event_efi_bsa_rehash(const tpm_event_t *, const tpm_parsed_event_t *, tpm_event_log_rehash_ctx_t *);
 static bool			__tpm_event_efi_bsa_extract_location(tpm_parsed_event_t *parsed);
-static bool			__tpm_event_efi_bsa_inspect_image(tpm_parsed_event_t *parsed);
+static bool			__tpm_event_efi_bsa_inspect_image(struct efi_bsa_event *evspec);
 
 static void
 __tpm_event_efi_bsa_destroy(tpm_parsed_event_t *parsed)
@@ -111,7 +111,7 @@ __tpm_event_parse_efi_bsa(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t 
 			assign_string(&ctx->efi_partition, evspec->efi_partition);
 		else
 			assign_string(&evspec->efi_partition, ctx->efi_partition);
-		__tpm_event_efi_bsa_inspect_image(parsed);
+		__tpm_event_efi_bsa_inspect_image(evspec);
 	}
 
 	return true;
@@ -150,9 +150,8 @@ __tpm_event_efi_bsa_extract_location(tpm_parsed_event_t *parsed)
 }
 
 static bool
-__tpm_event_efi_bsa_inspect_image(tpm_parsed_event_t *parsed)
+__tpm_event_efi_bsa_inspect_image(struct efi_bsa_event *evspec)
 {
-        struct efi_bsa_event *evspec = &parsed->efi_bsa_event;
 	char path[PATH_MAX];
 	const char *display_name;
 	buffer_t *img_data;
@@ -302,6 +301,7 @@ __tpm_event_efi_bsa_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *pars
 		if (new_application) {
 			evspec_clone = *evspec;
 			evspec_clone.efi_application = strdup(new_application);
+			__tpm_event_efi_bsa_inspect_image(&evspec_clone);
 			evspec = &evspec_clone;
 		}
 	}

--- a/src/efi-application.c
+++ b/src/efi-application.c
@@ -292,6 +292,12 @@ __tpm_event_efi_bsa_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *pars
 
 	/* The next boot can have a different kernel */
 	if (sdb_is_kernel(evspec->efi_application) && ctx->boot_entry) {
+		/* TODO: the parsed data type did not change, so all
+		 * the description correspond to the current event
+		 * log, and not the asset that has been measured.  The
+		 * debug output can then be missleading.
+		 */
+		debug("Measuring %s\n", ctx->boot_entry->image_path);
 		new_application = ctx->boot_entry->image_path;
 		if (new_application) {
 			evspec_clone = *evspec;

--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -790,8 +790,8 @@ static const tpm_evdigest_t *
 __tpm_event_systemd_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *parsed, tpm_event_log_rehash_ctx_t *ctx)
 {
 	const uapi_boot_entry_t *boot_entry = ctx->boot_entry;
-	char initrd[2048];
-	char initrd_utf16[4096];
+	char cmdline[2048];
+	char cmdline_utf16[4096];
 	unsigned int len;
 
 	/* If no --next-kernel option was given, do not rehash anything */
@@ -804,15 +804,16 @@ __tpm_event_systemd_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *pars
 	}
 
 	debug("Next boot entry expected from: %s %s\n", boot_entry->title, boot_entry->version? : "");
-	snprintf(initrd, sizeof(initrd), "initrd=%s %s",
+	snprintf(cmdline, sizeof(cmdline), "initrd=%s %s",
 			path_unix2dos(boot_entry->initrd_path),
 			boot_entry->options? : "");
+	debug("Measuring Kernel command line: %s\n", cmdline);
 
-	len = (strlen(initrd) + 1) << 1;
-	assert(len <= sizeof(initrd_utf16));
-	__convert_to_utf16le(initrd, strlen(initrd) + 1, initrd_utf16, len);
+	len = (strlen(cmdline) + 1) << 1;
+	assert(len <= sizeof(cmdline_utf16));
+	__convert_to_utf16le(cmdline, strlen(cmdline) + 1, cmdline_utf16, len);
 
-	return digest_compute(ctx->algo, initrd_utf16, len);
+	return digest_compute(ctx->algo, cmdline_utf16, len);
 }
 
 /*

--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -877,6 +877,7 @@ __tpm_event_tag_initrd_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *p
 	}
 
 	debug("Next boot entry expected from: %s %s\n", boot_entry->title, boot_entry->version? : "");
+	debug("Measuring initrd: %s\n", boot_entry->initrd_path);
 	return runtime_digest_efi_file(ctx->algo, boot_entry->initrd_path);
 }
 

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -366,6 +366,7 @@ pcr_bank_extend_register(tpm_pcr_bank_t *bank, unsigned int pcr_index, const tpm
 static void
 predictor_extend_hash(struct predictor *pred, unsigned int pcr_index, const tpm_evdigest_t *d)
 {
+	debug("Extend PCR#%d: %s\n", pcr_index, digest_print(d));
 	pcr_bank_extend_register(&pred->prediction, pcr_index, d);
 }
 


### PR DESCRIPTION
If the image of the event log is different from the one that should be predicted (for example, when there is a new kernel), we need to update the image information before the rehash.

Also add more output information, like the PCR that will be extended.  This can help to identify issues with collecting all the expansions in order with `grep "::: Extend PCR"`, for example.

