### PR TITLE
Fix secure boot issue when measuring the kernel

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -34,7 +34,8 @@ ORACLE_SRCS	= oracle.c \
 		  store.c \
 		  util.c \
 		  sd-boot.c \
-		  uapi.c
+		  uapi.c \
+		  secure_boot.c
 ORACLE_OBJS	= $(addprefix build/,$(patsubst %.c,%.o,$(ORACLE_SRCS)))
 
 all: $(TOOLS) $(MANPAGES)

--- a/configure
+++ b/configure
@@ -12,7 +12,7 @@
 # Invoke with --help for a description of options
 #
 # microconf:begin
-# version 0.5.4
+# version 0.5.5
 # require libtss2
 # require json
 # disable debug-authenticode

--- a/microconf/version
+++ b/microconf/version
@@ -1,1 +1,1 @@
-uc_version=0.5.4
+uc_version=0.5.5

--- a/src/efi-application.c
+++ b/src/efi-application.c
@@ -40,7 +40,7 @@
  */
 static const tpm_evdigest_t *	__tpm_event_efi_bsa_rehash(const tpm_event_t *, const tpm_parsed_event_t *, tpm_event_log_rehash_ctx_t *);
 static bool			__tpm_event_efi_bsa_extract_location(tpm_parsed_event_t *parsed);
-static bool			__tpm_event_efi_bsa_inspect_image(tpm_parsed_event_t *parsed);
+static bool			__tpm_event_efi_bsa_inspect_image(struct efi_bsa_event *evspec);
 
 static void
 __tpm_event_efi_bsa_destroy(tpm_parsed_event_t *parsed)
@@ -111,7 +111,7 @@ __tpm_event_parse_efi_bsa(tpm_event_t *ev, tpm_parsed_event_t *parsed, buffer_t 
 			assign_string(&ctx->efi_partition, evspec->efi_partition);
 		else
 			assign_string(&evspec->efi_partition, ctx->efi_partition);
-		__tpm_event_efi_bsa_inspect_image(parsed);
+		__tpm_event_efi_bsa_inspect_image(evspec);
 	}
 
 	return true;
@@ -150,9 +150,8 @@ __tpm_event_efi_bsa_extract_location(tpm_parsed_event_t *parsed)
 }
 
 static bool
-__tpm_event_efi_bsa_inspect_image(tpm_parsed_event_t *parsed)
+__tpm_event_efi_bsa_inspect_image(struct efi_bsa_event *evspec)
 {
-        struct efi_bsa_event *evspec = &parsed->efi_bsa_event;
 	char path[PATH_MAX];
 	const char *display_name;
 	buffer_t *img_data;
@@ -302,6 +301,7 @@ __tpm_event_efi_bsa_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *pars
 		if (new_application) {
 			evspec_clone = *evspec;
 			evspec_clone.efi_application = strdup(new_application);
+			__tpm_event_efi_bsa_inspect_image(&evspec_clone);
 			evspec = &evspec_clone;
 		}
 	}

--- a/src/efi-application.c
+++ b/src/efi-application.c
@@ -292,6 +292,12 @@ __tpm_event_efi_bsa_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *pars
 
 	/* The next boot can have a different kernel */
 	if (sdb_is_kernel(evspec->efi_application) && ctx->boot_entry) {
+		/* TODO: the parsed data type did not change, so all
+		 * the description correspond to the current event
+		 * log, and not the asset that has been measured.  The
+		 * debug output can then be missleading.
+		 */
+		debug("Measuring %s\n", ctx->boot_entry->image_path);
 		new_application = ctx->boot_entry->image_path;
 		if (new_application) {
 			evspec_clone = *evspec;

--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -790,8 +790,8 @@ static const tpm_evdigest_t *
 __tpm_event_systemd_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *parsed, tpm_event_log_rehash_ctx_t *ctx)
 {
 	const uapi_boot_entry_t *boot_entry = ctx->boot_entry;
-	char initrd[2048];
-	char initrd_utf16[4096];
+	char cmdline[2048];
+	char cmdline_utf16[4096];
 	unsigned int len;
 
 	/* If no --next-kernel option was given, do not rehash anything */
@@ -804,15 +804,16 @@ __tpm_event_systemd_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *pars
 	}
 
 	debug("Next boot entry expected from: %s %s\n", boot_entry->title, boot_entry->version? : "");
-	snprintf(initrd, sizeof(initrd), "initrd=%s %s",
+	snprintf(cmdline, sizeof(cmdline), "initrd=%s %s",
 			path_unix2dos(boot_entry->initrd_path),
 			boot_entry->options? : "");
+	debug("Measuring Kernel command line: %s\n", cmdline);
 
-	len = (strlen(initrd) + 1) << 1;
-	assert(len <= sizeof(initrd_utf16));
-	__convert_to_utf16le(initrd, strlen(initrd) + 1, initrd_utf16, len);
+	len = (strlen(cmdline) + 1) << 1;
+	assert(len <= sizeof(cmdline_utf16));
+	__convert_to_utf16le(cmdline, strlen(cmdline) + 1, cmdline_utf16, len);
 
-	return digest_compute(ctx->algo, initrd_utf16, len);
+	return digest_compute(ctx->algo, cmdline_utf16, len);
 }
 
 /*

--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -877,6 +877,7 @@ __tpm_event_tag_initrd_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *p
 	}
 
 	debug("Next boot entry expected from: %s %s\n", boot_entry->title, boot_entry->version? : "");
+	debug("Measuring initrd: %s\n", boot_entry->initrd_path);
 	return runtime_digest_efi_file(ctx->algo, boot_entry->initrd_path);
 }
 

--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -323,4 +323,6 @@ extern bool			shim_variable_name_valid(const char *name);
 extern const char *		shim_variable_get_rtname(const char *name);
 extern const char *		shim_variable_get_full_rtname(const char *name);
 
+extern bool			secure_boot_enabled();
+
 #endif /* EVENTLOG_H */

--- a/src/oracle.c
+++ b/src/oracle.c
@@ -366,6 +366,7 @@ pcr_bank_extend_register(tpm_pcr_bank_t *bank, unsigned int pcr_index, const tpm
 static void
 predictor_extend_hash(struct predictor *pred, unsigned int pcr_index, const tpm_evdigest_t *d)
 {
+	debug("Extend PCR#%d: %s\n", pcr_index, digest_print(d));
 	pcr_bank_extend_register(&pred->prediction, pcr_index, d);
 }
 

--- a/src/sd-boot.c
+++ b/src/sd-boot.c
@@ -138,6 +138,9 @@ sdb_is_kernel(const char *application)
 	char *path_copy;
 	int found = 0;
 
+	if (!application)
+		return false;
+
 	match = get_valid_kernel_entry_tokens();
 	path_copy = strdup(application);
 

--- a/src/secure_boot.c
+++ b/src/secure_boot.c
@@ -1,0 +1,44 @@
+/*
+ *   Copyright (C) 2023 SUSE LLC
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * Written by Alberto Planas <aplanas@suse.com>
+ */
+
+#include <stdio.h>
+#include "bufparser.h"
+#include "runtime.h"
+
+#define SECURE_BOOT_EFIVAR_NAME	"SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"
+
+
+bool
+secure_boot_enabled()
+{
+	buffer_t *data;
+	uint8_t enabled;
+
+	data = runtime_read_efi_variable(SECURE_BOOT_EFIVAR_NAME);
+	if (data == NULL) {
+		return false;
+	}
+
+	if (!buffer_get_u8(data,  &enabled)) {
+		 return false;
+	}
+
+	return enabled == 1;
+}


### PR DESCRIPTION
When secure boot is enabled, the device path for the kernel (PCR4) is not filled in the event log.  This makes the kernel not measured and the current hash of the event log reused.

This PR provides an heuristic to detect this situation, and use the next kernel parameter as a basis to build a new candidate that will be measured.

Build on top of https://github.com/okirch/pcr-oracle/pull/47