### PR TITLE
__tpm_event_grub_file_rehash: Assume /boot is outside of the ESP

### DIFF
--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -578,7 +578,8 @@ __tpm_event_grub_file_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *pa
 	const tpm_evdigest_t *md = NULL;
 
 	debug("  re-hashing %s\n", __tpm_event_grub_file_describe(parsed));
-	if (evspec->device == NULL || !strcmp(evspec->device, "crypto0")) {
+	if (evspec->device == NULL || !strcmp(evspec->device, "crypto0")
+	    || !strncmp("/boot/", evspec->path, 6)) {
 		debug("  assuming the file resides on system partition\n");
 		md = runtime_digest_rootfs_file(ctx->algo, evspec->path);
 	} else {


### PR DESCRIPTION
There is no /boot on the ESP, so improve the heuristic so it works without "crypto0".

I encountered this when running `pcr-oracle -d --from eventlog all --verify current` on a system without encrypted /.