### PR TITLE
Update json lib package name and makefile flags

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3,9 +3,9 @@ PKGNAME		= pcr-oracle-$(VERSION)
 
 CCOPT		= -O0 -g
 FIRSTBOOTDIR	= /usr/share/jeos-firstboot
-CFLAGS		= -Wall @TSS2_ESYS_CFLAGS@ @JSON_CFLAGS@ $(CCOPT)
+CFLAGS		= -Wall @TSS2_ESYS_CFLAGS@ @JSON_C_CFLAGS@ $(CCOPT)
 TSS2_LINK	= -ltss2-esys -ltss2-tctildr -ltss2-rc -ltss2-mu -lcrypto
-JSON_LINK	= -L@JSON_LIBDIR@ @JSON_LIBS@
+JSON_LINK	= -L@JSON_C_LIBDIR@ @JSON_C_LIBS@
 TOOLS		= pcr-oracle
 
 MANDIR		= @MANDIR@

--- a/microconf/stage3/05-json
+++ b/microconf/stage3/05-json
@@ -2,6 +2,6 @@
 # libjson version
 ##################################################################
 if [ -z "$uc_with_libjson" -o "$uc_with_libjson" = "detect" ]; then
-	uc_pkg_config_check_package json
+	uc_pkg_config_check_package json-c
 fi
 


### PR DESCRIPTION
The build failed (at least for me on Ubuntu 22.04) due to json lib not found by configure.
I tracked the problem to the lib name in `microconf/stage-3/05-json` and the flags in  `Makefile.in`.