### PR TITLE
Fix event rehash for grub files on system partition

### DIFF
--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -578,7 +578,8 @@ __tpm_event_grub_file_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *pa
 	const tpm_evdigest_t *md = NULL;
 
 	debug("  re-hashing %s\n", __tpm_event_grub_file_describe(parsed));
-	if (evspec->device == NULL || !strcmp(evspec->device, "crypto0")) {
+	if (evspec->device == NULL || !strcmp(evspec->device, "crypto0") ||
+	    !strncmp(evspec->device, "cryptouuid", strlen("cryptouuid"))) {
 		debug("  assuming the file resides on system partition\n");
 		md = runtime_digest_rootfs_file(ctx->algo, evspec->path);
 	} else {


### PR DESCRIPTION
The crypto device logged by grub may not be 'crypto0'. It could begin with the 'cryptouuid' prefix like this:

  cryptouuid/4203418d2b034db5b9476f013ee3dc80

This commit adds the additional prefix matching for 'cryptouuid' to make pcr-oracle to search the file on system partition.