### PR TITLE
Predict SbatLevelRT

### DIFF
--- a/src/authenticode.h
+++ b/src/authenticode.h
@@ -29,5 +29,7 @@ extern tpm_evdigest_t *	authenticode_get_digest(pecoff_image_info_t *, digest_ct
 extern cert_table_t *	authenticode_get_certificate_table(const pecoff_image_info_t *img);
 extern parsed_cert_t *	authenticode_get_signer(const pecoff_image_info_t *);
 
+extern buffer_t *	pecoff_image_get_sbatlevel(pecoff_image_info_t *);
+
 #endif /* AUTHENTICODE_H */
 

--- a/src/efi-application.c
+++ b/src/efi-application.c
@@ -280,6 +280,7 @@ __tpm_event_efi_bsa_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *pars
 	const struct efi_bsa_event *evspec = &parsed->efi_bsa_event;
 	const char *new_application;
 	struct efi_bsa_event evspec_clone;
+	buffer_t *sbatlevel;
 
 	/* Some BSA events do not refer to files, but to some data blobs residing somewhere on a device.
 	 * We're not yet prepared to handle these, so we hope the user doesn't mess with them, and
@@ -298,6 +299,14 @@ __tpm_event_efi_bsa_rehash(const tpm_event_t *ev, const tpm_parsed_event_t *pars
 			evspec_clone.efi_application = strdup(new_application);
 			evspec = &evspec_clone;
 		}
+	}
+
+	/* Set the sbatlevel section from shim.efi */
+	if (ctx->sbatlevel == NULL
+	 && (sbatlevel = pecoff_image_get_sbatlevel(evspec->img_info)) != NULL) {
+		if ((ctx->sbatlevel = buffer_alloc_write(sbatlevel->size)) == NULL
+		 || !buffer_copy(sbatlevel, sbatlevel->size, ctx->sbatlevel))
+			return NULL;
 	}
 
 	if (ctx->use_pesign)

--- a/src/efi-variable.c
+++ b/src/efi-variable.c
@@ -291,9 +291,9 @@ efi_variable_authority_get_record(const tpm_parsed_event_t *parsed, const char *
 		db_name = "MokList";
 	} else
 	if (!strcmp(var_short_name, "SbatLevel")) {
-		if (ctx->sbatlevel != NULL)
-			return efi_sbatlevel_get_record(ctx->sbatlevel);
-		return runtime_read_efi_variable(var_name);
+		if (ctx->sbatlevel == NULL)
+			fatal("No reference .sbatlevel section. Please add PCR4 into the PCR index list\n");
+		return efi_sbatlevel_get_record(ctx->sbatlevel);
 	} else {
 		/* Read as-is (this could be SbatLevel, or some other variable that's not
 		 * a signature db). */

--- a/src/eventlog.c
+++ b/src/eventlog.c
@@ -1001,6 +1001,7 @@ tpm_event_log_rehash_ctx_init(tpm_event_log_rehash_ctx_t *ctx, const tpm_algo_in
 void
 tpm_event_log_rehash_ctx_destroy(tpm_event_log_rehash_ctx_t *ctx)
 {
+	buffer_free(ctx->sbatlevel);
 }
 
 void

--- a/src/eventlog.h
+++ b/src/eventlog.h
@@ -203,6 +203,8 @@ typedef struct tpm_event_log_rehash_ctx {
 
 	/* This get set when the user specifies --next-kernel */
 	uapi_boot_entry_t *	boot_entry;
+
+	buffer_t *		sbatlevel;
 } tpm_event_log_rehash_ctx_t;
 
 #define GRUB_COMMAND_ARGV_MAX	32


### PR DESCRIPTION
The 'SbatLevelRT' variable may change after shim update, and that changes PCR7. This PR looks into shim.efi and tries to predict 'SbatLevelRT' for the next boot so that the policy digest in the sealed key can be updated correctly.